### PR TITLE
Add basic support for generating requests

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,3 @@
-# {Issue} OR {New feature} #
-
 :warning:
 
 New issue checklist:
@@ -13,11 +11,11 @@ New issue checklist:
 
 :warning:
 
-*Please change the section title with the right issue type.*
-
-## Short description ##
+# Short description #
 
 *Please fill this section with a short description of your issue / new feature.*
+
+-----
 
 **If the ticket is about an issue, use the following sections to give more details about the issue you're facing.**
 
@@ -27,7 +25,9 @@ New issue checklist:
 
 ### Actual outcome ###
 
-*Please fill this section with a description of what is actually happening. Please add as much information as you can (how easy it is to reproduce, steps, etc.).*
+*Please fill the following section with a description of what is actually happening. Please add as much information as you can (how easy it is to reproduce, steps, etc.).*
+
+-----
 
 **If the ticket is about a new feature, use the following sections to give more details about the changes you ask for / want to implement.**
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+reported by contacting the project team at damien.rivet@gmail.com. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@
 
 To get started on contributing on `JamfKit` you'll need to clone the repository from `GitHub`.
 
-`JamfKit` relies on a very few external libraries but still, you'll have to use `Carthage` to download the required dependencies.
+Next step will be to verify that you're using **XCode 9.2**.
 
 Once those two steps are completed, you'll be able to start contributing to `JamfKit`.
 

--- a/JamfKit/Configs/JamfKit.plist
+++ b/JamfKit/Configs/JamfKit.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2018 JamfKit. All rights reserved.</string>
+	<string>Copyright © 2017-present JamfKit. All rights reserved.</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/JamfKit/JamfKit.xcodeproj/project.pbxproj
+++ b/JamfKit/JamfKit.xcodeproj/project.pbxproj
@@ -143,6 +143,10 @@
 		ED91011B200516AA000935E8 /* ComputerCommandGeneral.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED910119200516AA000935E8 /* ComputerCommandGeneral.swift */; };
 		ED91011E200516E7000935E8 /* ComputerCommandGeneralTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED91011D200516E7000935E8 /* ComputerCommandGeneralTests.swift */; };
 		ED91011F200516E7000935E8 /* ComputerCommandGeneralTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED91011D200516E7000935E8 /* ComputerCommandGeneralTests.swift */; };
+		ED96A6AA203A1EE000C711D5 /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED96A6A9203A1EE000C711D5 /* StringExtension.swift */; };
+		ED96A6AB203A1EE000C711D5 /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED96A6A9203A1EE000C711D5 /* StringExtension.swift */; };
+		ED96A6AE203A1FB700C711D5 /* StringExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED96A6AD203A1FB700C711D5 /* StringExtensionTests.swift */; };
+		ED96A6AF203A1FB700C711D5 /* StringExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED96A6AD203A1FB700C711D5 /* StringExtensionTests.swift */; };
 		ED9826F51FEAB14300DD5411 /* Printer.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED9826F41FEAB14300DD5411 /* Printer.swift */; };
 		ED9826F61FEAB14300DD5411 /* Printer.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED9826F41FEAB14300DD5411 /* Printer.swift */; };
 		ED9EF3F11FEABC7E00676AB3 /* PrinterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED9EF3F01FEABC7E00676AB3 /* PrinterTests.swift */; };
@@ -201,6 +205,12 @@
 		EDC96DB62004C73000262530 /* ComputerGroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC96DB42004C73000262530 /* ComputerGroupTests.swift */; };
 		EDCE84B01FC3152E0066AA75 /* ComputerPurchasing.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDCE84AF1FC3152E0066AA75 /* ComputerPurchasing.swift */; };
 		EDCE84B11FC3152E0066AA75 /* ComputerPurchasing.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDCE84AF1FC3152E0066AA75 /* ComputerPurchasing.swift */; };
+		EDE3AA1F203C5F0E00ABB163 /* SMTPServerRequestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE3AA1E203C5F0E00ABB163 /* SMTPServerRequestsTests.swift */; };
+		EDE3AA20203C5F0E00ABB163 /* SMTPServerRequestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE3AA1E203C5F0E00ABB163 /* SMTPServerRequestsTests.swift */; };
+		EDE3AA23203C7BDB00ABB163 /* PolicyRequestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE3AA22203C7BDB00ABB163 /* PolicyRequestsTests.swift */; };
+		EDE3AA24203C7BDB00ABB163 /* PolicyRequestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE3AA22203C7BDB00ABB163 /* PolicyRequestsTests.swift */; };
+		EDE3AA26203C863F00ABB163 /* Subset.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE3AA25203C863F00ABB163 /* Subset.swift */; };
+		EDE3AA27203C863F00ABB163 /* Subset.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE3AA25203C863F00ABB163 /* Subset.swift */; };
 		EDF70B6920075944006B5DFF /* SessionManagerRequests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF70B6820075944006B5DFF /* SessionManagerRequests.swift */; };
 		EDF70B6A20075944006B5DFF /* SessionManagerRequests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF70B6820075944006B5DFF /* SessionManagerRequests.swift */; };
 		EDF70B6D20076067006B5DFF /* SessionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF70B6C20076067006B5DFF /* SessionManagerTests.swift */; };
@@ -304,6 +314,8 @@
 		ED9100C220050B4C000935E8 /* JamfKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JamfKit.h; sourceTree = "<group>"; };
 		ED910119200516AA000935E8 /* ComputerCommandGeneral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComputerCommandGeneral.swift; sourceTree = "<group>"; };
 		ED91011D200516E7000935E8 /* ComputerCommandGeneralTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComputerCommandGeneralTests.swift; sourceTree = "<group>"; };
+		ED96A6A9203A1EE000C711D5 /* StringExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtension.swift; sourceTree = "<group>"; };
+		ED96A6AD203A1FB700C711D5 /* StringExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtensionTests.swift; sourceTree = "<group>"; };
 		ED9826F41FEAB14300DD5411 /* Printer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Printer.swift; sourceTree = "<group>"; };
 		ED9EF3F01FEABC7E00676AB3 /* PrinterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrinterTests.swift; sourceTree = "<group>"; };
 		EDA3CFD11FFC100500B22D36 /* SMTPServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SMTPServer.swift; path = ../../../JamfKit/Sources/Models/SMTPServer.swift; sourceTree = "<group>"; };
@@ -334,6 +346,9 @@
 		EDC96DAF2004C5F400262530 /* ComputerGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComputerGroup.swift; sourceTree = "<group>"; };
 		EDC96DB42004C73000262530 /* ComputerGroupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComputerGroupTests.swift; sourceTree = "<group>"; };
 		EDCE84AF1FC3152E0066AA75 /* ComputerPurchasing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComputerPurchasing.swift; sourceTree = "<group>"; };
+		EDE3AA1E203C5F0E00ABB163 /* SMTPServerRequestsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SMTPServerRequestsTests.swift; sourceTree = "<group>"; };
+		EDE3AA22203C7BDB00ABB163 /* PolicyRequestsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PolicyRequestsTests.swift; sourceTree = "<group>"; };
+		EDE3AA25203C863F00ABB163 /* Subset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Subset.swift; sourceTree = "<group>"; };
 		EDF70B6820075944006B5DFF /* SessionManagerRequests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManagerRequests.swift; sourceTree = "<group>"; };
 		EDF70B6C20076067006B5DFF /* SessionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManagerTests.swift; sourceTree = "<group>"; };
 		EDF70B6F20076079006B5DFF /* SessionManagerRequestsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManagerRequestsTests.swift; sourceTree = "<group>"; };
@@ -409,11 +424,12 @@
 		8933C7811EB5B7E0000D00A4 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				ED47ED1420206FBC00AF1BF6 /* Constants.swift */,
+				ED96A6A8203A1EC900C711D5 /* Extensions */,
 				ED9100C220050B4C000935E8 /* JamfKit.h */,
 				ED1D93051FA20F43005589F5 /* Models */,
 				ED1D93061FA20F49005589F5 /* Protocols */,
 				ED0D101820066ED700E0001A /* Session */,
-				ED47ED1420206FBC00AF1BF6 /* Constants.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -421,6 +437,7 @@
 		8933C7831EB5B7EB000D00A4 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				ED96A6AC203A1F9F00C711D5 /* Extensions */,
 				ED3597811FAA1182006E3B66 /* Helpers */,
 				ED1D93071FA20F86005589F5 /* Models */,
 				ED71F2B31FA9ED720056790C /* Resources */,
@@ -503,6 +520,7 @@
 				EDB3318E2036D0B500F43D31 /* Identifiable.swift */,
 				ED21F25B2020D89600E4F852 /* Requestable.swift */,
 				EDB331912036D1DF00F43D31 /* Endpoint.swift */,
+				EDE3AA25203C863F00ABB163 /* Subset.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -602,10 +620,12 @@
 				ED3441B920370CCE0078450E /* MobileDevice */,
 				ED3441B820370CC50078450E /* MobileDeviceGroup */,
 				ED3441C1203714490078450E /* NetbootServerRequestsTests.swift */,
+				EDE3AA21203C7BA500ABB163 /* Policy */,
 				ED3441AC20370A820078450E /* PrinterRequestsTests.swift */,
 				ED3441AF20370B3F0078450E /* ScriptRequestsTests.swift */,
 				EDF70B6F20076079006B5DFF /* SessionManagerRequestsTests.swift */,
 				ED3441B220370BA30078450E /* SiteRequestsTests.swift */,
+				EDE3AA1E203C5F0E00ABB163 /* SMTPServerRequestsTests.swift */,
 				ED3441B520370C280078450E /* UserRequestsTests.swift */,
 			);
 			path = Requests;
@@ -733,6 +753,22 @@
 			path = ComputerCommand;
 			sourceTree = "<group>";
 		};
+		ED96A6A8203A1EC900C711D5 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				ED96A6A9203A1EE000C711D5 /* StringExtension.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
+		ED96A6AC203A1F9F00C711D5 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				ED96A6AD203A1FB700C711D5 /* StringExtensionTests.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		EDB9B9441FFF836500287739 /* Policy */ = {
 			isa = PBXGroup;
 			children = (
@@ -790,6 +826,14 @@
 				EDC96DB42004C73000262530 /* ComputerGroupTests.swift */,
 			);
 			path = ComputerGroup;
+			sourceTree = "<group>";
+		};
+		EDE3AA21203C7BA500ABB163 /* Policy */ = {
+			isa = PBXGroup;
+			children = (
+				EDE3AA22203C7BDB00ABB163 /* PolicyRequestsTests.swift */,
+			);
+			path = Policy;
 			sourceTree = "<group>";
 		};
 		EDF70B6B20076048006B5DFF /* Session */ = {
@@ -1020,6 +1064,7 @@
 				ED071F5B1FB33D11003FAB0E /* ComputerRemoteManagement.swift in Sources */,
 				ED7383A11FAB75CE006259FC /* User.swift in Sources */,
 				EDB9B94F1FFF83C000287739 /* PolicyNetworkLimitations.swift in Sources */,
+				EDE3AA26203C863F00ABB163 /* Subset.swift in Sources */,
 				EDC96DAC2004C54000262530 /* HardwareGroupCriterion.swift in Sources */,
 				ED4C59061FFE3CCE00E84A25 /* Package.swift in Sources */,
 				EDFE806E1FEA76EA00169C39 /* Building.swift in Sources */,
@@ -1034,6 +1079,7 @@
 				EDB3318F2036D0B500F43D31 /* Identifiable.swift in Sources */,
 				ED73839B1FAB5AD9006259FC /* Site.swift in Sources */,
 				ED56BB7F1FB1B24B00416C1A /* ComputerLocation.swift in Sources */,
+				ED96A6AA203A1EE000C711D5 /* StringExtension.swift in Sources */,
 				ED071F611FB34222003FAB0E /* PreciseDate.swift in Sources */,
 				EDB9B9491FFF838A00287739 /* PolicyGeneral.swift in Sources */,
 				EDCE84B01FC3152E0066AA75 /* ComputerPurchasing.swift in Sources */,
@@ -1100,6 +1146,7 @@
 				ED3441972036E73E0078450E /* BuildingRequestsTests.swift in Sources */,
 				ED680B062003C61200F80EDB /* ComputerConfigurationGeneralTest.swift in Sources */,
 				ED071F581FB333AF003FAB0E /* ComputerLocationTests.swift in Sources */,
+				EDE3AA1F203C5F0E00ABB163 /* SMTPServerRequestsTests.swift in Sources */,
 				ED34419E2036EA340078450E /* ComputerCommandRequestsTests.swift in Sources */,
 				ED169F2B1FFE742300DD7B61 /* ScriptTests.swift in Sources */,
 				ED3441AA2036EFD30078450E /* ComputerConfigurationRequestsTests.swift in Sources */,
@@ -1114,12 +1161,14 @@
 				ED3597831FAA11B6006E3B66 /* JSONHelper.swift in Sources */,
 				EDFE80711FEA773600169C39 /* BuildingTests.swift in Sources */,
 				ED3441B020370B3F0078450E /* ScriptRequestsTests.swift in Sources */,
+				EDE3AA23203C7BDB00ABB163 /* PolicyRequestsTests.swift in Sources */,
 				ED3441C2203714490078450E /* NetbootServerRequestsTests.swift in Sources */,
 				EDB9B95C1FFF9BA100287739 /* PolicyCategoryTests.swift in Sources */,
 				ED169F1C1FFE504000DD7B61 /* PackageTests.swift in Sources */,
 				EDB9B9591FFF9B8B00287739 /* PolicyTests.swift in Sources */,
 				ED3441A22036EE310078450E /* ComputerGroupRequestsTests.swift in Sources */,
 				ED2DF2AA2000213500FD0A30 /* HardwareGroupCriterionTests.swift in Sources */,
+				ED96A6AE203A1FB700C711D5 /* StringExtensionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1133,6 +1182,7 @@
 				ED071F5C1FB33D11003FAB0E /* ComputerRemoteManagement.swift in Sources */,
 				ED6C4AE31FAC61DF007B7026 /* User.swift in Sources */,
 				EDB9B9501FFF83C000287739 /* PolicyNetworkLimitations.swift in Sources */,
+				EDE3AA27203C863F00ABB163 /* Subset.swift in Sources */,
 				EDC96DAD2004C54000262530 /* HardwareGroupCriterion.swift in Sources */,
 				ED1D930F1FA20FB6005589F5 /* BaseObject.swift in Sources */,
 				ED4C59071FFE3CCE00E84A25 /* Package.swift in Sources */,
@@ -1147,6 +1197,7 @@
 				EDB331902036D0B500F43D31 /* Identifiable.swift in Sources */,
 				ED21F25D2020D89600E4F852 /* Requestable.swift in Sources */,
 				ED73839C1FAB5AD9006259FC /* Site.swift in Sources */,
+				ED96A6AB203A1EE000C711D5 /* StringExtension.swift in Sources */,
 				ED56BB801FB1B24B00416C1A /* ComputerLocation.swift in Sources */,
 				ED071F621FB34222003FAB0E /* PreciseDate.swift in Sources */,
 				EDB9B94A1FFF838A00287739 /* PolicyGeneral.swift in Sources */,
@@ -1213,6 +1264,7 @@
 				ED3441982036E73E0078450E /* BuildingRequestsTests.swift in Sources */,
 				ED680B072003C61200F80EDB /* ComputerConfigurationGeneralTest.swift in Sources */,
 				ED071F591FB333AF003FAB0E /* ComputerLocationTests.swift in Sources */,
+				EDE3AA20203C5F0E00ABB163 /* SMTPServerRequestsTests.swift in Sources */,
 				ED34419F2036EA340078450E /* ComputerCommandRequestsTests.swift in Sources */,
 				ED169F2C1FFE742300DD7B61 /* ScriptTests.swift in Sources */,
 				ED3441AB2036EFD30078450E /* ComputerConfigurationRequestsTests.swift in Sources */,
@@ -1227,12 +1279,14 @@
 				ED3597841FAA11B6006E3B66 /* JSONHelper.swift in Sources */,
 				EDFE80721FEA773600169C39 /* BuildingTests.swift in Sources */,
 				ED3441B120370B3F0078450E /* ScriptRequestsTests.swift in Sources */,
+				EDE3AA24203C7BDB00ABB163 /* PolicyRequestsTests.swift in Sources */,
 				ED3441C3203714490078450E /* NetbootServerRequestsTests.swift in Sources */,
 				EDB9B95D1FFF9BA100287739 /* PolicyCategoryTests.swift in Sources */,
 				ED169F1D1FFE504000DD7B61 /* PackageTests.swift in Sources */,
 				EDB9B95A1FFF9B8B00287739 /* PolicyTests.swift in Sources */,
 				ED3441A32036EE310078450E /* ComputerGroupRequestsTests.swift in Sources */,
 				ED2DF2AB2000213500FD0A30 /* HardwareGroupCriterionTests.swift in Sources */,
+				ED96A6AF203A1FB700C711D5 /* StringExtensionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/JamfKit/JamfKit.xcodeproj/project.pbxproj
+++ b/JamfKit/JamfKit.xcodeproj/project.pbxproj
@@ -97,6 +97,8 @@
 		ED3E04811FFCCA58001600CA /* NetworkSegment.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3E047F1FFCCA58001600CA /* NetworkSegment.swift */; };
 		ED3E04831FFCCDAD001600CA /* NetworkSegmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3E04821FFCCDAD001600CA /* NetworkSegmentTests.swift */; };
 		ED3E04841FFCCDAD001600CA /* NetworkSegmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3E04821FFCCDAD001600CA /* NetworkSegmentTests.swift */; };
+		ED406202203D81BA008B4B6A /* HardwareGroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED406201203D81BA008B4B6A /* HardwareGroupTests.swift */; };
+		ED406203203D81BA008B4B6A /* HardwareGroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED406201203D81BA008B4B6A /* HardwareGroupTests.swift */; };
 		ED47ED1220206B3A00AF1BF6 /* SessionManagerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED47ED1120206B3A00AF1BF6 /* SessionManagerError.swift */; };
 		ED47ED1320206B3A00AF1BF6 /* SessionManagerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED47ED1120206B3A00AF1BF6 /* SessionManagerError.swift */; };
 		ED47ED1520206FBC00AF1BF6 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED47ED1420206FBC00AF1BF6 /* Constants.swift */; };
@@ -291,6 +293,7 @@
 		ED3597821FAA11B6006E3B66 /* JSONHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONHelper.swift; sourceTree = "<group>"; };
 		ED3E047F1FFCCA58001600CA /* NetworkSegment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NetworkSegment.swift; path = ../../../JamfKit/Sources/Models/NetworkSegment.swift; sourceTree = "<group>"; };
 		ED3E04821FFCCDAD001600CA /* NetworkSegmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkSegmentTests.swift; sourceTree = "<group>"; };
+		ED406201203D81BA008B4B6A /* HardwareGroupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HardwareGroupTests.swift; sourceTree = "<group>"; };
 		ED47ED1120206B3A00AF1BF6 /* SessionManagerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManagerError.swift; sourceTree = "<group>"; };
 		ED47ED1420206FBC00AF1BF6 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		ED4C59051FFE3CCE00E84A25 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
@@ -516,10 +519,10 @@
 		ED1D93061FA20F49005589F5 /* Protocols */ = {
 			isa = PBXGroup;
 			children = (
-				ED3441882036E50E0078450E /* Requests */,
+				EDB331912036D1DF00F43D31 /* Endpoint.swift */,
 				EDB3318E2036D0B500F43D31 /* Identifiable.swift */,
 				ED21F25B2020D89600E4F852 /* Requestable.swift */,
-				EDB331912036D1DF00F43D31 /* Endpoint.swift */,
+				ED3441882036E50E0078450E /* Requests */,
 				EDE3AA25203C863F00ABB163 /* Subset.swift */,
 			);
 			path = Protocols;
@@ -816,6 +819,7 @@
 			isa = PBXGroup;
 			children = (
 				ED2DF2A92000213500FD0A30 /* HardwareGroupCriterionTests.swift */,
+				ED406201203D81BA008B4B6A /* HardwareGroupTests.swift */,
 			);
 			path = HardwareGroup;
 			sourceTree = "<group>";
@@ -1155,6 +1159,7 @@
 				EDA3CFD51FFC195100B22D36 /* SMTPServerTests.swift in Sources */,
 				ED1D93111FA20FB9005589F5 /* BaseObjectTests.swift in Sources */,
 				ED3441BB20370CE20078450E /* MobileDeviceRequestsTests.swift in Sources */,
+				ED406202203D81BA008B4B6A /* HardwareGroupTests.swift in Sources */,
 				ED3441A62036EF0C0078450E /* ComputerRequestsTests.swift in Sources */,
 				EDB9B9621FFF9BB500287739 /* PolicyGeneralTests.swift in Sources */,
 				EDF70B7020076079006B5DFF /* SessionManagerRequestsTests.swift in Sources */,
@@ -1273,6 +1278,7 @@
 				EDA3CFD61FFC195100B22D36 /* SMTPServerTests.swift in Sources */,
 				ED1D93101FA20FB9005589F5 /* BaseObjectTests.swift in Sources */,
 				ED3441BC20370CE20078450E /* MobileDeviceRequestsTests.swift in Sources */,
+				ED406203203D81BA008B4B6A /* HardwareGroupTests.swift in Sources */,
 				ED3441A72036EF0C0078450E /* ComputerRequestsTests.swift in Sources */,
 				EDB9B9631FFF9BB500287739 /* PolicyGeneralTests.swift in Sources */,
 				EDF70B7120076079006B5DFF /* SessionManagerRequestsTests.swift in Sources */,

--- a/JamfKit/JamfKit.xcodeproj/project.pbxproj
+++ b/JamfKit/JamfKit.xcodeproj/project.pbxproj
@@ -37,12 +37,12 @@
 		ED1B70E41FEA973A00005658 /* Department.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1B70E21FEA973A00005658 /* Department.swift */; };
 		ED1B70E61FEA981800005658 /* DepartmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1B70E51FEA981800005658 /* DepartmentTests.swift */; };
 		ED1B70E71FEA981800005658 /* DepartmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1B70E51FEA981800005658 /* DepartmentTests.swift */; };
-		ED1D930B1FA20FAB005589F5 /* Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1D930A1FA20FAB005589F5 /* Identifiable.swift */; };
 		ED1D930D1FA20FB0005589F5 /* BaseObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1D930C1FA20FB0005589F5 /* BaseObject.swift */; };
-		ED1D930E1FA20FB3005589F5 /* Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1D930A1FA20FAB005589F5 /* Identifiable.swift */; };
 		ED1D930F1FA20FB6005589F5 /* BaseObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1D930C1FA20FB0005589F5 /* BaseObject.swift */; };
 		ED1D93101FA20FB9005589F5 /* BaseObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1D93081FA20F86005589F5 /* BaseObjectTests.swift */; };
 		ED1D93111FA20FB9005589F5 /* BaseObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1D93081FA20F86005589F5 /* BaseObjectTests.swift */; };
+		ED21F25C2020D89600E4F852 /* Requestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED21F25B2020D89600E4F852 /* Requestable.swift */; };
+		ED21F25D2020D89600E4F852 /* Requestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED21F25B2020D89600E4F852 /* Requestable.swift */; };
 		ED2DF2A72000206300FD0A30 /* MobileDeviceGroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED2DF2A62000206300FD0A30 /* MobileDeviceGroupTests.swift */; };
 		ED2DF2A82000206300FD0A30 /* MobileDeviceGroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED2DF2A62000206300FD0A30 /* MobileDeviceGroupTests.swift */; };
 		ED2DF2AA2000213500FD0A30 /* HardwareGroupCriterionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED2DF2A92000213500FD0A30 /* HardwareGroupCriterionTests.swift */; };
@@ -55,6 +55,42 @@
 		ED326B8B1FFD2AAA00809793 /* MobileDeviceGeneralTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED326B891FFD2AAA00809793 /* MobileDeviceGeneralTests.swift */; };
 		ED326B8D1FFD2AB500809793 /* MobileDeviceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED326B8C1FFD2AB500809793 /* MobileDeviceTests.swift */; };
 		ED326B8E1FFD2AB500809793 /* MobileDeviceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED326B8C1FFD2AB500809793 /* MobileDeviceTests.swift */; };
+		ED34418A2036E5210078450E /* Creatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3441892036E5210078450E /* Creatable.swift */; };
+		ED34418B2036E5210078450E /* Creatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3441892036E5210078450E /* Creatable.swift */; };
+		ED34418D2036E5470078450E /* Deletable.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED34418C2036E5470078450E /* Deletable.swift */; };
+		ED34418E2036E5470078450E /* Deletable.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED34418C2036E5470078450E /* Deletable.swift */; };
+		ED3441902036E5520078450E /* Readable.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED34418F2036E5520078450E /* Readable.swift */; };
+		ED3441912036E5520078450E /* Readable.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED34418F2036E5520078450E /* Readable.swift */; };
+		ED3441932036E55C0078450E /* Updatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3441922036E55C0078450E /* Updatable.swift */; };
+		ED3441942036E55C0078450E /* Updatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3441922036E55C0078450E /* Updatable.swift */; };
+		ED3441972036E73E0078450E /* BuildingRequestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3441962036E73E0078450E /* BuildingRequestsTests.swift */; };
+		ED3441982036E73E0078450E /* BuildingRequestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3441962036E73E0078450E /* BuildingRequestsTests.swift */; };
+		ED34419A2036E9AB0078450E /* DepartmentRequestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3441992036E9AB0078450E /* DepartmentRequestsTests.swift */; };
+		ED34419B2036E9AB0078450E /* DepartmentRequestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3441992036E9AB0078450E /* DepartmentRequestsTests.swift */; };
+		ED34419E2036EA340078450E /* ComputerCommandRequestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED34419D2036EA340078450E /* ComputerCommandRequestsTests.swift */; };
+		ED34419F2036EA340078450E /* ComputerCommandRequestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED34419D2036EA340078450E /* ComputerCommandRequestsTests.swift */; };
+		ED3441A22036EE310078450E /* ComputerGroupRequestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3441A12036EE310078450E /* ComputerGroupRequestsTests.swift */; };
+		ED3441A32036EE310078450E /* ComputerGroupRequestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3441A12036EE310078450E /* ComputerGroupRequestsTests.swift */; };
+		ED3441A62036EF0C0078450E /* ComputerRequestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3441A52036EF0C0078450E /* ComputerRequestsTests.swift */; };
+		ED3441A72036EF0C0078450E /* ComputerRequestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3441A52036EF0C0078450E /* ComputerRequestsTests.swift */; };
+		ED3441AA2036EFD30078450E /* ComputerConfigurationRequestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3441A92036EFD30078450E /* ComputerConfigurationRequestsTests.swift */; };
+		ED3441AB2036EFD30078450E /* ComputerConfigurationRequestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3441A92036EFD30078450E /* ComputerConfigurationRequestsTests.swift */; };
+		ED3441AD20370A820078450E /* PrinterRequestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3441AC20370A820078450E /* PrinterRequestsTests.swift */; };
+		ED3441AE20370A820078450E /* PrinterRequestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3441AC20370A820078450E /* PrinterRequestsTests.swift */; };
+		ED3441B020370B3F0078450E /* ScriptRequestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3441AF20370B3F0078450E /* ScriptRequestsTests.swift */; };
+		ED3441B120370B3F0078450E /* ScriptRequestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3441AF20370B3F0078450E /* ScriptRequestsTests.swift */; };
+		ED3441B320370BA30078450E /* SiteRequestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3441B220370BA30078450E /* SiteRequestsTests.swift */; };
+		ED3441B420370BA30078450E /* SiteRequestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3441B220370BA30078450E /* SiteRequestsTests.swift */; };
+		ED3441B620370C280078450E /* UserRequestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3441B520370C280078450E /* UserRequestsTests.swift */; };
+		ED3441B720370C280078450E /* UserRequestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3441B520370C280078450E /* UserRequestsTests.swift */; };
+		ED3441BB20370CE20078450E /* MobileDeviceRequestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3441BA20370CE20078450E /* MobileDeviceRequestsTests.swift */; };
+		ED3441BC20370CE20078450E /* MobileDeviceRequestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3441BA20370CE20078450E /* MobileDeviceRequestsTests.swift */; };
+		ED3441BF20370D930078450E /* MobileDeviceGroupRequestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3441BE20370D930078450E /* MobileDeviceGroupRequestsTests.swift */; };
+		ED3441C020370D930078450E /* MobileDeviceGroupRequestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3441BE20370D930078450E /* MobileDeviceGroupRequestsTests.swift */; };
+		ED3441C2203714490078450E /* NetbootServerRequestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3441C1203714490078450E /* NetbootServerRequestsTests.swift */; };
+		ED3441C3203714490078450E /* NetbootServerRequestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3441C1203714490078450E /* NetbootServerRequestsTests.swift */; };
+		ED3441C5203714C60078450E /* DirectoryBindingRequestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3441C4203714C60078450E /* DirectoryBindingRequestsTests.swift */; };
+		ED3441C6203714C60078450E /* DirectoryBindingRequestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3441C4203714C60078450E /* DirectoryBindingRequestsTests.swift */; };
 		ED3597831FAA11B6006E3B66 /* JSONHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3597821FAA11B6006E3B66 /* JSONHelper.swift */; };
 		ED3597841FAA11B6006E3B66 /* JSONHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3597821FAA11B6006E3B66 /* JSONHelper.swift */; };
 		ED3E04801FFCCA58001600CA /* NetworkSegment.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3E047F1FFCCA58001600CA /* NetworkSegment.swift */; };
@@ -115,6 +151,10 @@
 		EDA3CFD31FFC100500B22D36 /* SMTPServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDA3CFD11FFC100500B22D36 /* SMTPServer.swift */; };
 		EDA3CFD51FFC195100B22D36 /* SMTPServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDA3CFD41FFC195100B22D36 /* SMTPServerTests.swift */; };
 		EDA3CFD61FFC195100B22D36 /* SMTPServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDA3CFD41FFC195100B22D36 /* SMTPServerTests.swift */; };
+		EDB3318F2036D0B500F43D31 /* Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB3318E2036D0B500F43D31 /* Identifiable.swift */; };
+		EDB331902036D0B500F43D31 /* Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB3318E2036D0B500F43D31 /* Identifiable.swift */; };
+		EDB331922036D1DF00F43D31 /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB331912036D1DF00F43D31 /* Endpoint.swift */; };
+		EDB331932036D1DF00F43D31 /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB331912036D1DF00F43D31 /* Endpoint.swift */; };
 		EDB698FB1FECEF6000C021E6 /* NetbootServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB698FA1FECEF6000C021E6 /* NetbootServer.swift */; };
 		EDB698FC1FECEF6000C021E6 /* NetbootServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB698FA1FECEF6000C021E6 /* NetbootServer.swift */; };
 		EDB698FE1FECF20800C021E6 /* NetbootServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB698FD1FECF20800C021E6 /* NetbootServerTests.swift */; };
@@ -212,14 +252,32 @@
 		ED1B70E21FEA973A00005658 /* Department.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Department.swift; sourceTree = "<group>"; };
 		ED1B70E51FEA981800005658 /* DepartmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DepartmentTests.swift; sourceTree = "<group>"; };
 		ED1D93081FA20F86005589F5 /* BaseObjectTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseObjectTests.swift; sourceTree = "<group>"; };
-		ED1D930A1FA20FAB005589F5 /* Identifiable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Identifiable.swift; sourceTree = "<group>"; };
 		ED1D930C1FA20FB0005589F5 /* BaseObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseObject.swift; sourceTree = "<group>"; };
+		ED21F25B2020D89600E4F852 /* Requestable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Requestable.swift; sourceTree = "<group>"; };
 		ED2DF2A62000206300FD0A30 /* MobileDeviceGroupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileDeviceGroupTests.swift; sourceTree = "<group>"; };
 		ED2DF2A92000213500FD0A30 /* HardwareGroupCriterionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HardwareGroupCriterionTests.swift; sourceTree = "<group>"; };
 		ED326B811FFD1B3900809793 /* MobileDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileDevice.swift; sourceTree = "<group>"; };
 		ED326B851FFD1D6200809793 /* MobileDeviceGeneral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MobileDeviceGeneral.swift; path = ../../../../JamfKit/Sources/Models/MobileDevice/MobileDeviceGeneral.swift; sourceTree = "<group>"; };
 		ED326B891FFD2AAA00809793 /* MobileDeviceGeneralTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MobileDeviceGeneralTests.swift; path = ../../../../JamfKit/Tests/Models/MobileDevice/MobileDeviceGeneralTests.swift; sourceTree = "<group>"; };
 		ED326B8C1FFD2AB500809793 /* MobileDeviceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileDeviceTests.swift; sourceTree = "<group>"; };
+		ED3441892036E5210078450E /* Creatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Creatable.swift; sourceTree = "<group>"; };
+		ED34418C2036E5470078450E /* Deletable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Deletable.swift; sourceTree = "<group>"; };
+		ED34418F2036E5520078450E /* Readable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Readable.swift; sourceTree = "<group>"; };
+		ED3441922036E55C0078450E /* Updatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Updatable.swift; sourceTree = "<group>"; };
+		ED3441962036E73E0078450E /* BuildingRequestsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildingRequestsTests.swift; sourceTree = "<group>"; };
+		ED3441992036E9AB0078450E /* DepartmentRequestsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DepartmentRequestsTests.swift; sourceTree = "<group>"; };
+		ED34419D2036EA340078450E /* ComputerCommandRequestsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComputerCommandRequestsTests.swift; sourceTree = "<group>"; };
+		ED3441A12036EE310078450E /* ComputerGroupRequestsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComputerGroupRequestsTests.swift; sourceTree = "<group>"; };
+		ED3441A52036EF0C0078450E /* ComputerRequestsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComputerRequestsTests.swift; sourceTree = "<group>"; };
+		ED3441A92036EFD30078450E /* ComputerConfigurationRequestsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComputerConfigurationRequestsTests.swift; sourceTree = "<group>"; };
+		ED3441AC20370A820078450E /* PrinterRequestsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrinterRequestsTests.swift; sourceTree = "<group>"; };
+		ED3441AF20370B3F0078450E /* ScriptRequestsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptRequestsTests.swift; sourceTree = "<group>"; };
+		ED3441B220370BA30078450E /* SiteRequestsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteRequestsTests.swift; sourceTree = "<group>"; };
+		ED3441B520370C280078450E /* UserRequestsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRequestsTests.swift; sourceTree = "<group>"; };
+		ED3441BA20370CE20078450E /* MobileDeviceRequestsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileDeviceRequestsTests.swift; sourceTree = "<group>"; };
+		ED3441BE20370D930078450E /* MobileDeviceGroupRequestsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileDeviceGroupRequestsTests.swift; sourceTree = "<group>"; };
+		ED3441C1203714490078450E /* NetbootServerRequestsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetbootServerRequestsTests.swift; sourceTree = "<group>"; };
+		ED3441C4203714C60078450E /* DirectoryBindingRequestsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectoryBindingRequestsTests.swift; sourceTree = "<group>"; };
 		ED3597821FAA11B6006E3B66 /* JSONHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONHelper.swift; sourceTree = "<group>"; };
 		ED3E047F1FFCCA58001600CA /* NetworkSegment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NetworkSegment.swift; path = ../../../JamfKit/Sources/Models/NetworkSegment.swift; sourceTree = "<group>"; };
 		ED3E04821FFCCDAD001600CA /* NetworkSegmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkSegmentTests.swift; sourceTree = "<group>"; };
@@ -250,6 +308,8 @@
 		ED9EF3F01FEABC7E00676AB3 /* PrinterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrinterTests.swift; sourceTree = "<group>"; };
 		EDA3CFD11FFC100500B22D36 /* SMTPServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SMTPServer.swift; path = ../../../JamfKit/Sources/Models/SMTPServer.swift; sourceTree = "<group>"; };
 		EDA3CFD41FFC195100B22D36 /* SMTPServerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SMTPServerTests.swift; path = ../../../JamfKit/Tests/Models/SMTPServerTests.swift; sourceTree = "<group>"; };
+		EDB3318E2036D0B500F43D31 /* Identifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Identifiable.swift; sourceTree = "<group>"; };
+		EDB331912036D1DF00F43D31 /* Endpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Endpoint.swift; sourceTree = "<group>"; };
 		EDB698FA1FECEF6000C021E6 /* NetbootServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetbootServer.swift; sourceTree = "<group>"; };
 		EDB698FD1FECF20800C021E6 /* NetbootServerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetbootServerTests.swift; sourceTree = "<group>"; };
 		EDB9B93D1FFF712400287739 /* ComputerCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComputerCommand.swift; sourceTree = "<group>"; };
@@ -266,6 +326,7 @@
 		EDB9B9611FFF9BB500287739 /* PolicyGeneralTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PolicyGeneralTests.swift; sourceTree = "<group>"; };
 		EDB9B9641FFF9BC000287739 /* PolicyNetworkLimitationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PolicyNetworkLimitationsTests.swift; sourceTree = "<group>"; };
 		EDB9B9671FFF9BCD00287739 /* PolicyOverrideDefaultSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PolicyOverrideDefaultSettingsTests.swift; sourceTree = "<group>"; };
+		EDBED6C12020E53000DF308F /* Examples.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = Examples.playground; sourceTree = "<group>"; };
 		EDC6644F1FFFC87C00504DDB /* Partition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Partition.swift; sourceTree = "<group>"; };
 		EDC664521FFFCA7600504DDB /* PartitionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PartitionTests.swift; sourceTree = "<group>"; };
 		EDC96DA82004C52F00262530 /* HardwareGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HardwareGroup.swift; sourceTree = "<group>"; };
@@ -318,6 +379,7 @@
 			isa = PBXGroup;
 			children = (
 				52D6D99C1BEFF38C002C0205 /* Configs */,
+				ED21F25E2020DD5900E4F852 /* Playgrounds */,
 				52D6D97D1BEFF229002C0205 /* Products */,
 				8933C7811EB5B7E0000D00A4 /* Sources */,
 				8933C7831EB5B7EB000D00A4 /* Tests */,
@@ -398,8 +460,8 @@
 		ED0D101820066ED700E0001A /* Session */ = {
 			isa = PBXGroup;
 			children = (
+				ED21F25A2020D84500E4F852 /* Requests */,
 				ED0D101920066FC000E0001A /* SessionManager.swift */,
-				EDF70B6820075944006B5DFF /* SessionManagerRequests.swift */,
 				ED47ED1120206B3A00AF1BF6 /* SessionManagerError.swift */,
 			);
 			path = Session;
@@ -437,7 +499,10 @@
 		ED1D93061FA20F49005589F5 /* Protocols */ = {
 			isa = PBXGroup;
 			children = (
-				ED1D930A1FA20FAB005589F5 /* Identifiable.swift */,
+				ED3441882036E50E0078450E /* Requests */,
+				EDB3318E2036D0B500F43D31 /* Identifiable.swift */,
+				ED21F25B2020D89600E4F852 /* Requestable.swift */,
+				EDB331912036D1DF00F43D31 /* Endpoint.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -445,10 +510,10 @@
 		ED1D93071FA20F86005589F5 /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				ED91011C200516D0000935E8 /* ComputerCommand */,
 				ED1D93081FA20F86005589F5 /* BaseObjectTests.swift */,
 				EDFE80701FEA773600169C39 /* BuildingTests.swift */,
 				ED071F501FB33386003FAB0E /* Computer */,
+				ED91011C200516D0000935E8 /* ComputerCommand */,
 				ED680AFB2003C10600F80EDB /* ComputerConfiguration */,
 				EDC96DB32004C6DF00262530 /* ComputerGroup */,
 				ED1B70E51FEA981800005658 /* DepartmentTests.swift */,
@@ -469,6 +534,22 @@
 				ED7383A21FAB7D5A006259FC /* UserTests.swift */,
 			);
 			path = Models;
+			sourceTree = "<group>";
+		};
+		ED21F25A2020D84500E4F852 /* Requests */ = {
+			isa = PBXGroup;
+			children = (
+				EDF70B6820075944006B5DFF /* SessionManagerRequests.swift */,
+			);
+			path = Requests;
+			sourceTree = "<group>";
+		};
+		ED21F25E2020DD5900E4F852 /* Playgrounds */ = {
+			isa = PBXGroup;
+			children = (
+				EDBED6C12020E53000DF308F /* Examples.playground */,
+			);
+			path = Playgrounds;
 			sourceTree = "<group>";
 		};
 		ED2DF2A52000204D00FD0A30 /* MobileDeviceGroup */ = {
@@ -493,6 +574,87 @@
 			children = (
 				ED326B891FFD2AAA00809793 /* MobileDeviceGeneralTests.swift */,
 				ED326B8C1FFD2AB500809793 /* MobileDeviceTests.swift */,
+			);
+			path = MobileDevice;
+			sourceTree = "<group>";
+		};
+		ED3441882036E50E0078450E /* Requests */ = {
+			isa = PBXGroup;
+			children = (
+				ED3441892036E5210078450E /* Creatable.swift */,
+				ED34418C2036E5470078450E /* Deletable.swift */,
+				ED34418F2036E5520078450E /* Readable.swift */,
+				ED3441922036E55C0078450E /* Updatable.swift */,
+			);
+			path = Requests;
+			sourceTree = "<group>";
+		};
+		ED3441952036E71E0078450E /* Requests */ = {
+			isa = PBXGroup;
+			children = (
+				ED3441962036E73E0078450E /* BuildingRequestsTests.swift */,
+				ED3441A42036EEFC0078450E /* Computer */,
+				ED34419C2036EA170078450E /* ComputerCommand */,
+				ED3441A82036EFBF0078450E /* ComputerConfiguration */,
+				ED3441A02036EE1B0078450E /* ComputerGroup */,
+				ED3441992036E9AB0078450E /* DepartmentRequestsTests.swift */,
+				ED3441C4203714C60078450E /* DirectoryBindingRequestsTests.swift */,
+				ED3441B920370CCE0078450E /* MobileDevice */,
+				ED3441B820370CC50078450E /* MobileDeviceGroup */,
+				ED3441C1203714490078450E /* NetbootServerRequestsTests.swift */,
+				ED3441AC20370A820078450E /* PrinterRequestsTests.swift */,
+				ED3441AF20370B3F0078450E /* ScriptRequestsTests.swift */,
+				EDF70B6F20076079006B5DFF /* SessionManagerRequestsTests.swift */,
+				ED3441B220370BA30078450E /* SiteRequestsTests.swift */,
+				ED3441B520370C280078450E /* UserRequestsTests.swift */,
+			);
+			path = Requests;
+			sourceTree = "<group>";
+		};
+		ED34419C2036EA170078450E /* ComputerCommand */ = {
+			isa = PBXGroup;
+			children = (
+				ED34419D2036EA340078450E /* ComputerCommandRequestsTests.swift */,
+			);
+			path = ComputerCommand;
+			sourceTree = "<group>";
+		};
+		ED3441A02036EE1B0078450E /* ComputerGroup */ = {
+			isa = PBXGroup;
+			children = (
+				ED3441A12036EE310078450E /* ComputerGroupRequestsTests.swift */,
+			);
+			path = ComputerGroup;
+			sourceTree = "<group>";
+		};
+		ED3441A42036EEFC0078450E /* Computer */ = {
+			isa = PBXGroup;
+			children = (
+				ED3441A52036EF0C0078450E /* ComputerRequestsTests.swift */,
+			);
+			path = Computer;
+			sourceTree = "<group>";
+		};
+		ED3441A82036EFBF0078450E /* ComputerConfiguration */ = {
+			isa = PBXGroup;
+			children = (
+				ED3441A92036EFD30078450E /* ComputerConfigurationRequestsTests.swift */,
+			);
+			path = ComputerConfiguration;
+			sourceTree = "<group>";
+		};
+		ED3441B820370CC50078450E /* MobileDeviceGroup */ = {
+			isa = PBXGroup;
+			children = (
+				ED3441BE20370D930078450E /* MobileDeviceGroupRequestsTests.swift */,
+			);
+			path = MobileDeviceGroup;
+			sourceTree = "<group>";
+		};
+		ED3441B920370CCE0078450E /* MobileDevice */ = {
+			isa = PBXGroup;
+			children = (
+				ED3441BA20370CE20078450E /* MobileDeviceRequestsTests.swift */,
 			);
 			path = MobileDevice;
 			sourceTree = "<group>";
@@ -633,7 +795,7 @@
 		EDF70B6B20076048006B5DFF /* Session */ = {
 			isa = PBXGroup;
 			children = (
-				EDF70B6F20076079006B5DFF /* SessionManagerRequestsTests.swift */,
+				ED3441952036E71E0078450E /* Requests */,
 				EDF70B6C20076067006B5DFF /* SessionManagerTests.swift */,
 			);
 			path = Session;
@@ -859,14 +1021,17 @@
 				ED7383A11FAB75CE006259FC /* User.swift in Sources */,
 				EDB9B94F1FFF83C000287739 /* PolicyNetworkLimitations.swift in Sources */,
 				EDC96DAC2004C54000262530 /* HardwareGroupCriterion.swift in Sources */,
-				ED1D930B1FA20FAB005589F5 /* Identifiable.swift in Sources */,
 				ED4C59061FFE3CCE00E84A25 /* Package.swift in Sources */,
 				EDFE806E1FEA76EA00169C39 /* Building.swift in Sources */,
 				ED9826F51FEAB14300DD5411 /* Printer.swift in Sources */,
 				EDB9B94C1FFF83AF00287739 /* PolicyDateTimeLimitations.swift in Sources */,
 				EDF70B6920075944006B5DFF /* SessionManagerRequests.swift in Sources */,
+				ED3441932036E55C0078450E /* Updatable.swift in Sources */,
 				EDB9B93E1FFF712400287739 /* ComputerCommand.swift in Sources */,
+				ED34418A2036E5210078450E /* Creatable.swift in Sources */,
 				ED72A2BE2000125D0047E0B7 /* MobileDeviceGroup.swift in Sources */,
+				ED21F25C2020D89600E4F852 /* Requestable.swift in Sources */,
+				EDB3318F2036D0B500F43D31 /* Identifiable.swift in Sources */,
 				ED73839B1FAB5AD9006259FC /* Site.swift in Sources */,
 				ED56BB7F1FB1B24B00416C1A /* ComputerLocation.swift in Sources */,
 				ED071F611FB34222003FAB0E /* PreciseDate.swift in Sources */,
@@ -878,10 +1043,12 @@
 				ED1D930D1FA20FB0005589F5 /* BaseObject.swift in Sources */,
 				ED47ED1520206FBC00AF1BF6 /* Constants.swift in Sources */,
 				ED680AF92003B05E00F80EDB /* ComputerConfigurationManagement.swift in Sources */,
+				ED34418D2036E5470078450E /* Deletable.swift in Sources */,
 				ED169F221FFE5F2F00DD7B61 /* DirectoryBinding.swift in Sources */,
 				ED3E04801FFCCA58001600CA /* NetworkSegment.swift in Sources */,
 				EDC664501FFFC87C00504DDB /* Partition.swift in Sources */,
 				ED680B032003C56C00F80EDB /* ComputerConfigurationGeneral.swift in Sources */,
+				ED3441902036E5520078450E /* Readable.swift in Sources */,
 				EDB698FB1FECEF6000C021E6 /* NetbootServer.swift in Sources */,
 				EDC96DA92004C52F00262530 /* HardwareGroup.swift in Sources */,
 				EDA3CFD21FFC100500B22D36 /* SMTPServer.swift in Sources */,
@@ -892,6 +1059,7 @@
 				ED0D101A20066FC000E0001A /* SessionManager.swift in Sources */,
 				ED47ED1220206B3A00AF1BF6 /* SessionManagerError.swift in Sources */,
 				ED7BF1051FFCD9C100F47566 /* Computer.swift in Sources */,
+				EDB331922036D1DF00F43D31 /* Endpoint.swift in Sources */,
 				ED1B70E31FEA973A00005658 /* Department.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -903,8 +1071,10 @@
 				ED7BF1081FFCDA9100F47566 /* ComputerTests.swift in Sources */,
 				ED3E04831FFCCDAD001600CA /* NetworkSegmentTests.swift in Sources */,
 				EDB698FE1FECF20800C021E6 /* NetbootServerTests.swift in Sources */,
+				ED3441BF20370D930078450E /* MobileDeviceGroupRequestsTests.swift in Sources */,
 				ED071F5E1FB33DF9003FAB0E /* ComputerRemoteManagementTests.swift in Sources */,
 				EDB9B9401FFF73A700287739 /* ComputerCommandTests.swift in Sources */,
+				ED3441AD20370A820078450E /* PrinterRequestsTests.swift in Sources */,
 				ED91011E200516E7000935E8 /* ComputerCommandGeneralTests.swift in Sources */,
 				ED5B01471FB357F8005F0C47 /* PreciseDateTests.swift in Sources */,
 				ED169F241FFE613900DD7B61 /* DirectoryBindingTests.swift in Sources */,
@@ -915,28 +1085,40 @@
 				ED1B70E61FEA981800005658 /* DepartmentTests.swift in Sources */,
 				EDC96DB52004C73000262530 /* ComputerGroupTests.swift in Sources */,
 				ED2DF2A72000206300FD0A30 /* MobileDeviceGroupTests.swift in Sources */,
+				ED3441B620370C280078450E /* UserRequestsTests.swift in Sources */,
 				EDB9B95F1FFF9BAD00287739 /* PolicyDateTimeLimitationsTests.swift in Sources */,
+				ED3441B320370BA30078450E /* SiteRequestsTests.swift in Sources */,
 				ED9EF3F11FEABC7E00676AB3 /* PrinterTests.swift in Sources */,
+				ED3441C5203714C60078450E /* DirectoryBindingRequestsTests.swift in Sources */,
 				EDF70B6D20076067006B5DFF /* SessionManagerTests.swift in Sources */,
 				ED7383A31FAB7D5A006259FC /* UserTests.swift in Sources */,
+				ED34419A2036E9AB0078450E /* DepartmentRequestsTests.swift in Sources */,
 				ED326B8A1FFD2AAA00809793 /* MobileDeviceGeneralTests.swift in Sources */,
 				ED7BF10B1FFCE03400F47566 /* ComputerPurchasingTests.swift in Sources */,
 				ED680B002003C12E00F80EDB /* ComputerConfigurationManagementTests.swift in Sources */,
 				ED73839E1FAB5B09006259FC /* SiteTests.swift in Sources */,
+				ED3441972036E73E0078450E /* BuildingRequestsTests.swift in Sources */,
 				ED680B062003C61200F80EDB /* ComputerConfigurationGeneralTest.swift in Sources */,
 				ED071F581FB333AF003FAB0E /* ComputerLocationTests.swift in Sources */,
+				ED34419E2036EA340078450E /* ComputerCommandRequestsTests.swift in Sources */,
 				ED169F2B1FFE742300DD7B61 /* ScriptTests.swift in Sources */,
+				ED3441AA2036EFD30078450E /* ComputerConfigurationRequestsTests.swift in Sources */,
 				ED326B8D1FFD2AB500809793 /* MobileDeviceTests.swift in Sources */,
 				EDC664531FFFCA7600504DDB /* PartitionTests.swift in Sources */,
 				EDA3CFD51FFC195100B22D36 /* SMTPServerTests.swift in Sources */,
 				ED1D93111FA20FB9005589F5 /* BaseObjectTests.swift in Sources */,
+				ED3441BB20370CE20078450E /* MobileDeviceRequestsTests.swift in Sources */,
+				ED3441A62036EF0C0078450E /* ComputerRequestsTests.swift in Sources */,
 				EDB9B9621FFF9BB500287739 /* PolicyGeneralTests.swift in Sources */,
 				EDF70B7020076079006B5DFF /* SessionManagerRequestsTests.swift in Sources */,
 				ED3597831FAA11B6006E3B66 /* JSONHelper.swift in Sources */,
 				EDFE80711FEA773600169C39 /* BuildingTests.swift in Sources */,
+				ED3441B020370B3F0078450E /* ScriptRequestsTests.swift in Sources */,
+				ED3441C2203714490078450E /* NetbootServerRequestsTests.swift in Sources */,
 				EDB9B95C1FFF9BA100287739 /* PolicyCategoryTests.swift in Sources */,
 				ED169F1C1FFE504000DD7B61 /* PackageTests.swift in Sources */,
 				EDB9B9591FFF9B8B00287739 /* PolicyTests.swift in Sources */,
+				ED3441A22036EE310078450E /* ComputerGroupRequestsTests.swift in Sources */,
 				ED2DF2AA2000213500FD0A30 /* HardwareGroupCriterionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -957,9 +1139,13 @@
 				EDFE806F1FEA76EA00169C39 /* Building.swift in Sources */,
 				ED9826F61FEAB14300DD5411 /* Printer.swift in Sources */,
 				EDB9B94D1FFF83AF00287739 /* PolicyDateTimeLimitations.swift in Sources */,
+				ED3441942036E55C0078450E /* Updatable.swift in Sources */,
 				EDF70B6A20075944006B5DFF /* SessionManagerRequests.swift in Sources */,
+				ED34418B2036E5210078450E /* Creatable.swift in Sources */,
 				EDB9B9421FFF7B6400287739 /* ComputerCommand.swift in Sources */,
 				ED72A2BF2000125D0047E0B7 /* MobileDeviceGroup.swift in Sources */,
+				EDB331902036D0B500F43D31 /* Identifiable.swift in Sources */,
+				ED21F25D2020D89600E4F852 /* Requestable.swift in Sources */,
 				ED73839C1FAB5AD9006259FC /* Site.swift in Sources */,
 				ED56BB801FB1B24B00416C1A /* ComputerLocation.swift in Sources */,
 				ED071F621FB34222003FAB0E /* PreciseDate.swift in Sources */,
@@ -968,13 +1154,14 @@
 				EDB9B9471FFF837B00287739 /* Policy.swift in Sources */,
 				ED071F4F1FB33275003FAB0E /* ComputerGeneral.swift in Sources */,
 				EDB9B9531FFF83D600287739 /* PolicyOverrideDefaultSettings.swift in Sources */,
-				ED1D930E1FA20FB3005589F5 /* Identifiable.swift in Sources */,
 				ED47ED1620206FBC00AF1BF6 /* Constants.swift in Sources */,
 				ED680AFA2003B05E00F80EDB /* ComputerConfigurationManagement.swift in Sources */,
+				ED34418E2036E5470078450E /* Deletable.swift in Sources */,
 				ED169F291FFE6D8F00DD7B61 /* DirectoryBinding.swift in Sources */,
 				ED3E04811FFCCA58001600CA /* NetworkSegment.swift in Sources */,
 				EDC664511FFFC87C00504DDB /* Partition.swift in Sources */,
 				ED680B042003C56C00F80EDB /* ComputerConfigurationGeneral.swift in Sources */,
+				ED3441912036E5520078450E /* Readable.swift in Sources */,
 				EDB698FC1FECEF6000C021E6 /* NetbootServer.swift in Sources */,
 				EDC96DAA2004C52F00262530 /* HardwareGroup.swift in Sources */,
 				EDA3CFD31FFC100500B22D36 /* SMTPServer.swift in Sources */,
@@ -985,6 +1172,7 @@
 				ED0D101B20066FC000E0001A /* SessionManager.swift in Sources */,
 				ED47ED1320206B3A00AF1BF6 /* SessionManagerError.swift in Sources */,
 				ED7BF1061FFCD9C100F47566 /* Computer.swift in Sources */,
+				EDB331932036D1DF00F43D31 /* Endpoint.swift in Sources */,
 				ED1B70E41FEA973A00005658 /* Department.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -996,8 +1184,10 @@
 				ED7BF1091FFCDA9100F47566 /* ComputerTests.swift in Sources */,
 				ED3E04841FFCCDAD001600CA /* NetworkSegmentTests.swift in Sources */,
 				EDB698FF1FECF20800C021E6 /* NetbootServerTests.swift in Sources */,
+				ED3441C020370D930078450E /* MobileDeviceGroupRequestsTests.swift in Sources */,
 				ED071F5F1FB33DF9003FAB0E /* ComputerRemoteManagementTests.swift in Sources */,
 				EDB9B9411FFF73A700287739 /* ComputerCommandTests.swift in Sources */,
+				ED3441AE20370A820078450E /* PrinterRequestsTests.swift in Sources */,
 				ED91011F200516E7000935E8 /* ComputerCommandGeneralTests.swift in Sources */,
 				ED5B01481FB357F8005F0C47 /* PreciseDateTests.swift in Sources */,
 				ED169F251FFE613900DD7B61 /* DirectoryBindingTests.swift in Sources */,
@@ -1008,28 +1198,40 @@
 				ED1B70E71FEA981800005658 /* DepartmentTests.swift in Sources */,
 				EDC96DB62004C73000262530 /* ComputerGroupTests.swift in Sources */,
 				ED2DF2A82000206300FD0A30 /* MobileDeviceGroupTests.swift in Sources */,
+				ED3441B720370C280078450E /* UserRequestsTests.swift in Sources */,
 				EDB9B9601FFF9BAD00287739 /* PolicyDateTimeLimitationsTests.swift in Sources */,
+				ED3441B420370BA30078450E /* SiteRequestsTests.swift in Sources */,
 				ED9EF3F21FEABC7E00676AB3 /* PrinterTests.swift in Sources */,
+				ED3441C6203714C60078450E /* DirectoryBindingRequestsTests.swift in Sources */,
 				EDF70B6E20076067006B5DFF /* SessionManagerTests.swift in Sources */,
 				ED7383A41FAB7D5A006259FC /* UserTests.swift in Sources */,
+				ED34419B2036E9AB0078450E /* DepartmentRequestsTests.swift in Sources */,
 				ED326B8B1FFD2AAA00809793 /* MobileDeviceGeneralTests.swift in Sources */,
 				ED7BF10C1FFCE03400F47566 /* ComputerPurchasingTests.swift in Sources */,
 				ED680B012003C12E00F80EDB /* ComputerConfigurationManagementTests.swift in Sources */,
 				ED73839F1FAB5B09006259FC /* SiteTests.swift in Sources */,
+				ED3441982036E73E0078450E /* BuildingRequestsTests.swift in Sources */,
 				ED680B072003C61200F80EDB /* ComputerConfigurationGeneralTest.swift in Sources */,
 				ED071F591FB333AF003FAB0E /* ComputerLocationTests.swift in Sources */,
+				ED34419F2036EA340078450E /* ComputerCommandRequestsTests.swift in Sources */,
 				ED169F2C1FFE742300DD7B61 /* ScriptTests.swift in Sources */,
+				ED3441AB2036EFD30078450E /* ComputerConfigurationRequestsTests.swift in Sources */,
 				ED326B8E1FFD2AB500809793 /* MobileDeviceTests.swift in Sources */,
 				EDC664541FFFCA7600504DDB /* PartitionTests.swift in Sources */,
 				EDA3CFD61FFC195100B22D36 /* SMTPServerTests.swift in Sources */,
 				ED1D93101FA20FB9005589F5 /* BaseObjectTests.swift in Sources */,
+				ED3441BC20370CE20078450E /* MobileDeviceRequestsTests.swift in Sources */,
+				ED3441A72036EF0C0078450E /* ComputerRequestsTests.swift in Sources */,
 				EDB9B9631FFF9BB500287739 /* PolicyGeneralTests.swift in Sources */,
 				EDF70B7120076079006B5DFF /* SessionManagerRequestsTests.swift in Sources */,
 				ED3597841FAA11B6006E3B66 /* JSONHelper.swift in Sources */,
 				EDFE80721FEA773600169C39 /* BuildingTests.swift in Sources */,
+				ED3441B120370B3F0078450E /* ScriptRequestsTests.swift in Sources */,
+				ED3441C3203714490078450E /* NetbootServerRequestsTests.swift in Sources */,
 				EDB9B95D1FFF9BA100287739 /* PolicyCategoryTests.swift in Sources */,
 				ED169F1D1FFE504000DD7B61 /* PackageTests.swift in Sources */,
 				EDB9B95A1FFF9B8B00287739 /* PolicyTests.swift in Sources */,
+				ED3441A32036EE310078450E /* ComputerGroupRequestsTests.swift in Sources */,
 				ED2DF2AB2000213500FD0A30 /* HardwareGroupCriterionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/JamfKit/Playgrounds/Examples.playground/Pages/Classes.xcplaygroundpage/Contents.swift
+++ b/JamfKit/Playgrounds/Examples.playground/Pages/Classes.xcplaygroundpage/Contents.swift
@@ -1,0 +1,31 @@
+//: [Previous](@previous)
+
+//: # JamfKit - Requests
+
+//: 1. Import JamfKit
+
+import JamfKit
+
+//: 2. Instantiate any class you need for your current usage
+
+let building = Building(identifier: 12345, name: "Building")
+let computer = Computer(identifier: 12345, name: "Computer")
+let computerCommand = ComputerCommand(command: "Command", passcode: 12345)
+let computerConfiguration = ComputerConfiguration(identifier: 12345, name: "Computer configuration")
+let computerGroup = ComputerGroup(identifier: 12345, name: "Computer group")
+let department = Department(identifier: 12345, name: "Department")
+let directoryBinding = DirectoryBinding(identifier: 12345, name: "Directory binding")
+let mobileDevice = MobileDevice(identifier: 12345, name: "Mobile device")
+let mobileDeviceGroup = MobileDeviceGroup(identifier: 12345, name: "Mobile device group")
+let netbootServer = NetbootServer(identifier: 12345, name: "Netboot server")
+let networkSegment = NetworkSegment(identifier: 12345, name: "Network segment")
+let package = Package(identifier: 12345, name: "Package")
+let partition = Partition(name: "Partition")
+let policy = Policy(identifier: 12345, name: "Policy")
+let printer = Printer(identifier: 12345, name: "Printer")
+let script = Script(identifier: 12345, name: "Script")
+let site = Site(identifier: 12345, name: "Site")
+let smtpServer = SMTPServer(host: "127.0.0.1", port: 1234)
+let user = User(identifier: 12345, name: "User")
+
+//: [Next](@next)

--- a/JamfKit/Playgrounds/Examples.playground/Pages/Requests.xcplaygroundpage/Contents.swift
+++ b/JamfKit/Playgrounds/Examples.playground/Pages/Requests.xcplaygroundpage/Contents.swift
@@ -1,0 +1,29 @@
+//: [Previous](@previous)
+
+//: # JamfKit - Requests
+
+//: 1. Import JamfKit
+
+import JamfKit
+
+//: 2. Configure the global instance of the `SessionManager`
+
+try SessionManager.instance.configure(for: "http://localhost", username: "john", password: "appleseed")
+
+//: 3. Use any instanciated model that is conforming to `Requestable`
+
+let building = Building(json: ["id": UInt(12345), "name": "test"])!
+
+
+
+//: 4. Generate any request directly from the global instance of the `SessionManager`
+
+let request = SessionManager.instance.request(for: building, method: .delete)
+
+//: #### Output
+
+print(request?.httpMethod)
+print(request?.url)
+print(request?.allHTTPHeaderFields)
+
+//: [Next](@next)

--- a/JamfKit/Playgrounds/Examples.playground/Pages/Requests.xcplaygroundpage/Contents.swift
+++ b/JamfKit/Playgrounds/Examples.playground/Pages/Requests.xcplaygroundpage/Contents.swift
@@ -12,18 +12,39 @@ try SessionManager.instance.configure(for: "http://localhost", username: "john",
 
 //: 3. Use any instanciated model that is conforming to `Requestable`
 
-let building = Building(json: ["id": UInt(12345), "name": "test"])!
+let building = Building(json: ["id": UInt(12345), "name": "Building"])!
 
+//: 4. Generate any request directly from the JSS object
 
-
-//: 4. Generate any request directly from the global instance of the `SessionManager`
-
-let request = SessionManager.instance.request(for: building, method: .delete)
+let readAllRequest = Building.readAll()
+let createRequest = building.create()
+let readRequest = building.read()
+let updateRequest = building.update()
+let deleteRequest = building.delete()
 
 //: #### Output
 
-print(request?.httpMethod)
-print(request?.url)
-print(request?.allHTTPHeaderFields)
+print("\n##### READ ALL")
+print(readAllRequest?.httpMethod)
+print(readAllRequest?.url)
+print(readAllRequest?.allHTTPHeaderFields)
+print("\n##### CREATE")
+print(createRequest?.httpMethod)
+print(createRequest?.url)
+print(createRequest?.allHTTPHeaderFields)
+print(createRequest?.httpBody)
+print("\n##### READ")
+print(readRequest?.httpMethod)
+print(readRequest?.url)
+print(readRequest?.allHTTPHeaderFields)
+print("\n##### UPDATE")
+print(updateRequest?.httpMethod)
+print(updateRequest?.url)
+print(updateRequest?.allHTTPHeaderFields)
+print(updateRequest?.httpBody)
+print("\n##### DELETE")
+print(deleteRequest?.httpMethod)
+print(deleteRequest?.url)
+print(deleteRequest?.allHTTPHeaderFields)
 
 //: [Next](@next)

--- a/JamfKit/Playgrounds/Examples.playground/Pages/Requests.xcplaygroundpage/Contents.swift
+++ b/JamfKit/Playgrounds/Examples.playground/Pages/Requests.xcplaygroundpage/Contents.swift
@@ -8,31 +8,38 @@ import JamfKit
 
 //: 2. Configure the global instance of the `SessionManager`
 
-try SessionManager.instance.configure(for: "http://localhost", username: "john", password: "appleseed")
+try SessionManager.instance.configure(for: "http://localhost/jss", username: "john", password: "appleseed")
 
 //: 3. Use any instanciated model that is conforming to `Requestable`
 
-let building = Building(json: ["id": UInt(12345), "name": "Building"])!
+let building = Building(json: ["id": UInt(12345), "name": "Some building"])!
 
-//: 4. Generate any request directly from the JSS object
+//: 4. Generate any request directly from the JSS class / object
 
-let readAllRequest = Building.readAll()
-let createRequest = building.create()
-let readRequest = building.read()
-let updateRequest = building.update()
-let deleteRequest = building.delete()
+let readAllRequest = Building.readAllRequest()
+let createRequest = building.createRequest()
+let readStaticRequest = Building.readRequest(identifier: "12345")
+let readRequest = building.readRequest()
+let updateRequest = building.updateRequest()
+let deleteStaticRequest = Building.deleteRequest(identifier: "12345")
+let deleteRequest = building.deleteRequest()
+let deleteRequestWithName = building.deleteRequestWithName()
 
 //: #### Output
 
-print("\n##### READ ALL")
-print(readAllRequest?.httpMethod)
-print(readAllRequest?.url)
-print(readAllRequest?.allHTTPHeaderFields)
 print("\n##### CREATE")
 print(createRequest?.httpMethod)
 print(createRequest?.url)
 print(createRequest?.allHTTPHeaderFields)
 print(createRequest?.httpBody)
+print("\n##### READ ALL")
+print(readAllRequest?.httpMethod)
+print(readAllRequest?.url)
+print(readAllRequest?.allHTTPHeaderFields)
+print("\n##### READ STATIC")
+print(readStaticRequest?.httpMethod)
+print(readStaticRequest?.url)
+print(readStaticRequest?.allHTTPHeaderFields)
 print("\n##### READ")
 print(readRequest?.httpMethod)
 print(readRequest?.url)
@@ -42,9 +49,17 @@ print(updateRequest?.httpMethod)
 print(updateRequest?.url)
 print(updateRequest?.allHTTPHeaderFields)
 print(updateRequest?.httpBody)
+print("\n##### DELETE STATIC")
+print(deleteStaticRequest?.httpMethod)
+print(deleteStaticRequest?.url)
+print(deleteStaticRequest?.allHTTPHeaderFields)
 print("\n##### DELETE")
 print(deleteRequest?.httpMethod)
 print(deleteRequest?.url)
 print(deleteRequest?.allHTTPHeaderFields)
+print("\n##### DELETE WITH NAME")
+print(deleteRequestWithName?.httpMethod)
+print(deleteRequestWithName?.url)
+print(deleteRequestWithName?.allHTTPHeaderFields)
 
 //: [Next](@next)

--- a/JamfKit/Playgrounds/Examples.playground/Pages/Summary.xcplaygroundpage/Contents.swift
+++ b/JamfKit/Playgrounds/Examples.playground/Pages/Summary.xcplaygroundpage/Contents.swift
@@ -1,0 +1,5 @@
+//: # JamfKit - Playgrounds
+
+//: You'll find below the summary of the available Playgrounds to get you started with `JamfKit`.
+
+//: [Requests](Requests)

--- a/JamfKit/Playgrounds/Examples.playground/Pages/Summary.xcplaygroundpage/Contents.swift
+++ b/JamfKit/Playgrounds/Examples.playground/Pages/Summary.xcplaygroundpage/Contents.swift
@@ -2,4 +2,6 @@
 
 //: You'll find below the summary of the available Playgrounds to get you started with `JamfKit`.
 
+//: [Classes](Classes)
+
 //: [Requests](Requests)

--- a/JamfKit/Playgrounds/Examples.playground/contents.xcplayground
+++ b/JamfKit/Playgrounds/Examples.playground/contents.xcplayground
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='6.0' target-platform='ios' display-mode='raw'>
+<playground version='6.0' target-platform='ios' display-mode='rendered'>
     <pages>
         <page name='Summary'/>
         <page name='Classes'/>

--- a/JamfKit/Playgrounds/Examples.playground/contents.xcplayground
+++ b/JamfKit/Playgrounds/Examples.playground/contents.xcplayground
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<playground version='6.0' target-platform='ios' display-mode='raw'>
+    <pages>
+        <page name='Summary'/>
+        <page name='Requests'/>
+    </pages>
+</playground>

--- a/JamfKit/Playgrounds/Examples.playground/contents.xcplayground
+++ b/JamfKit/Playgrounds/Examples.playground/contents.xcplayground
@@ -2,6 +2,7 @@
 <playground version='6.0' target-platform='ios' display-mode='raw'>
     <pages>
         <page name='Summary'/>
+        <page name='Classes'/>
         <page name='Requests'/>
     </pages>
 </playground>

--- a/JamfKit/Sources/Constants.swift
+++ b/JamfKit/Sources/Constants.swift
@@ -6,7 +6,7 @@
 //  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
-internal struct Constants {
+struct Constants {
 
     static let domain = "com.github.ethenyl.JamfKit"
 }

--- a/JamfKit/Sources/Constants.swift
+++ b/JamfKit/Sources/Constants.swift
@@ -2,12 +2,11 @@
 //  Constants.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 internal struct Constants {
-
-    // MARK: - Constants
 
     static let domain = "com.github.ethenyl.JamfKit"
 }

--- a/JamfKit/Sources/Extensions/StringExtension.swift
+++ b/JamfKit/Sources/Extensions/StringExtension.swift
@@ -1,0 +1,17 @@
+//
+//  StringExtension.swift
+//  JamfKit
+//
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+//
+
+internal extension String {
+
+    // MARK: - Functions
+
+    /// Returns the String without useless characters
+    func asCleanedKey() -> String {
+        return self.replacingOccurrences(of: "_", with: "")
+    }
+}

--- a/JamfKit/Sources/Extensions/StringExtension.swift
+++ b/JamfKit/Sources/Extensions/StringExtension.swift
@@ -6,7 +6,7 @@
 //  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
-internal extension String {
+extension String {
 
     // MARK: - Functions
 

--- a/JamfKit/Sources/JamfKit.h
+++ b/JamfKit/Sources/JamfKit.h
@@ -2,7 +2,8 @@
 //  JamfKit.h
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 #import <Foundation/Foundation.h>

--- a/JamfKit/Sources/Models/BaseObject.swift
+++ b/JamfKit/Sources/Models/BaseObject.swift
@@ -44,17 +44,6 @@ public class BaseObject: NSObject, Requestable, Identifiable {
         self.name = name
     }
 
-    public init?(identifier: UInt, name: String) {
-        guard !name.isEmpty else {
-            return nil
-        }
-
-        self.identifier = identifier
-        self.name = name
-
-        super.init()
-    }
-
     // MARK: - Functions
 
     @objc

--- a/JamfKit/Sources/Models/BaseObject.swift
+++ b/JamfKit/Sources/Models/BaseObject.swift
@@ -44,6 +44,18 @@ public class BaseObject: NSObject, Requestable, Identifiable {
         self.name = name
     }
 
+    @objc
+    public init?(identifier: UInt, name: String) {
+        guard !name.isEmpty else {
+            return nil
+        }
+
+        self.identifier = identifier
+        self.name = name
+
+        super.init()
+    }
+
     // MARK: - Functions
 
     @objc

--- a/JamfKit/Sources/Models/BaseObject.swift
+++ b/JamfKit/Sources/Models/BaseObject.swift
@@ -1,20 +1,21 @@
 //
-//  Identifiable.swift
+//  BaseObject.swift
 //  JamfKit
 //
-//  Copyright © 2017 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
-
-import Foundation
 
 /// Represents the common denominator between all the JSS objects which must contains at least an `identifier` and a `name` properties.
 @objc
-public class BaseObject: NSObject, Identifiable {
+public class BaseObject: NSObject, Requestable, Identifiable {
 
     // MARK: - Constants
 
-    static let IdentifierKey = "id"
-    static let NameKey = "name"
+    enum CodingKeys: String {
+        case identifier = "id"
+        case name = "name"
+    }
 
     // MARK: - Properties
 
@@ -22,7 +23,7 @@ public class BaseObject: NSObject, Identifiable {
     public let identifier: UInt
 
     @objc
-    public let name: String
+    public var name: String
 
     public override var description: String {
         return "[\(String(describing: type(of: self)))][\(identifier) - \(self.name)]"
@@ -30,10 +31,11 @@ public class BaseObject: NSObject, Identifiable {
 
     // MARK: - Initialization
 
+    @objc
     public required init?(json: [String: Any], node: String = "") {
         guard
-            let identifier = json[BaseObject.IdentifierKey] as? UInt,
-            let name = json[BaseObject.NameKey] as? String
+            let identifier = json[BaseObject.CodingKeys.identifier.rawValue] as? UInt,
+            let name = json[BaseObject.CodingKeys.name.rawValue] as? String
             else {
                 return nil
         }
@@ -42,13 +44,25 @@ public class BaseObject: NSObject, Identifiable {
         self.name = name
     }
 
+    public init?(identifier: UInt, name: String) {
+        guard !name.isEmpty else {
+            return nil
+        }
+
+        self.identifier = identifier
+        self.name = name
+
+        super.init()
+    }
+
     // MARK: - Functions
 
+    @objc
     public func toJSON() -> [String: Any] {
         var json = [String: Any]()
 
-        json[BaseObject.IdentifierKey] = identifier
-        json[BaseObject.NameKey] = name
+        json[BaseObject.CodingKeys.identifier.rawValue] = identifier
+        json[BaseObject.CodingKeys.name.rawValue] = name
 
         return json
     }
@@ -61,7 +75,7 @@ public class BaseObject: NSObject, Identifiable {
      * - Parameter singleNodeKey: The string key used to identify a single element within the main node.
      *
      */
-    internal static func parseElements<Element: Identifiable>(from json: [String: Any], nodeKey: String, singleNodeKey: String) -> [Element] {
+    internal static func parseElements<Element: Requestable>(from json: [String: Any], nodeKey: String, singleNodeKey: String) -> [Element] {
         var elements = [Element]()
 
         guard let elementsNode = json[nodeKey] as? [[String: [String: Any]]] else {

--- a/JamfKit/Sources/Models/BaseObject.swift
+++ b/JamfKit/Sources/Models/BaseObject.swift
@@ -76,7 +76,7 @@ public class BaseObject: NSObject, Requestable, Identifiable {
      * - Parameter singleNodeKey: The string key used to identify a single element within the main node.
      *
      */
-    internal static func parseElements<Element: Requestable>(from json: [String: Any], nodeKey: String, singleNodeKey: String) -> [Element] {
+    static func parseElements<Element: Requestable>(from json: [String: Any], nodeKey: String, singleNodeKey: String) -> [Element] {
         var elements = [Element]()
 
         guard let elementsNode = json[nodeKey] as? [[String: [String: Any]]] else {

--- a/JamfKit/Sources/Models/Building.swift
+++ b/JamfKit/Sources/Models/Building.swift
@@ -12,11 +12,9 @@ public final class Building: BaseObject { }
 
 // MARK: - Protocols
 
-extension Building: Endpoint, Creatable {
+extension Building: Endpoint, Creatable, Readable, Updatable, Deletable {
 
-    // MARK: - Properties
+    // MARK: - Constants
 
-    public var endpoint: String {
-        return "buildings"
-    }
+    public static var Endpoint: String = "buildings"
 }

--- a/JamfKit/Sources/Models/Building.swift
+++ b/JamfKit/Sources/Models/Building.swift
@@ -15,6 +15,15 @@ public final class Building: BaseObject, Endpoint {
     public static let Endpoint: String = "buildings"
 }
 
+// MARK: - Creatable
+
+extension Building: Creatable {
+
+    public func create() -> URLRequest? {
+        return self.createRequest()
+    }
+}
+
 // MARK: - Protocols
 
-extension Building: Creatable, Readable, Updatable, Deletable { }
+extension Building: Readable, Updatable, Deletable { }

--- a/JamfKit/Sources/Models/Building.swift
+++ b/JamfKit/Sources/Models/Building.swift
@@ -2,11 +2,21 @@
 //  Building.swift
 //  JamfKit
 //
-//  Copyright © 2017 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
-
-import Foundation
 
 /// Represents a physical building.
 @objc(JMFKBuilding)
 public final class Building: BaseObject { }
+
+// MARK: - Protocols
+
+extension Building: Endpoint, Creatable {
+
+    // MARK: - Properties
+
+    public var endpoint: String {
+        return "buildings"
+    }
+}

--- a/JamfKit/Sources/Models/Building.swift
+++ b/JamfKit/Sources/Models/Building.swift
@@ -8,13 +8,13 @@
 
 /// Represents a physical building.
 @objc(JMFKBuilding)
-public final class Building: BaseObject { }
-
-// MARK: - Protocols
-
-extension Building: Endpoint, Creatable, Readable, Updatable, Deletable {
+public final class Building: BaseObject, Endpoint {
 
     // MARK: - Constants
 
-    public static var Endpoint: String = "buildings"
+    public static let Endpoint: String = "buildings"
 }
+
+// MARK: - Protocols
+
+extension Building: Creatable, Readable, Updatable, Deletable { }

--- a/JamfKit/Sources/Models/Building.swift
+++ b/JamfKit/Sources/Models/Building.swift
@@ -19,11 +19,71 @@ public final class Building: BaseObject, Endpoint {
 
 extension Building: Creatable {
 
-    public func create() -> URLRequest? {
-        return self.createRequest()
+    public func createRequest() -> URLRequest? {
+        return getCreateRequest()
     }
 }
 
-// MARK: - Protocols
+// MARK: - Readable
 
-extension Building: Readable, Updatable, Deletable { }
+extension Building: Readable {
+
+    public static func readAllRequest() -> URLRequest? {
+        return getReadAllRequest()
+    }
+
+    public static func readRequest(identifier: String) -> URLRequest? {
+        return getReadRequest(identifier: identifier)
+    }
+
+    public func readRequest() -> URLRequest? {
+        return getReadRequest()
+    }
+
+    /// Returns a GET **URLRequest** based on the supplied name.
+    public static func readRequest(name: String) -> URLRequest? {
+        return getReadRequest(name: name)
+    }
+
+    /// Returns a GET **URLRequest** based on the email.
+    public func readRequestWithName() -> URLRequest? {
+        return getReadRequestWithName()
+    }
+}
+
+// MARK: - Updatable
+
+extension Building: Updatable {
+
+    public func updateRequest() -> URLRequest? {
+        return getUpdateRequest()
+    }
+
+    /// Returns a PUT **URLRequest** based on the name.
+    public func updateRequestWithName() -> URLRequest? {
+        return getUpdateRequestWithName()
+    }
+}
+
+// MARK: - Deletable
+
+extension Building: Deletable {
+
+    public static func deleteRequest(identifier: String) -> URLRequest? {
+        return getDeleteRequest(identifier: identifier)
+    }
+
+    public func deleteRequest() -> URLRequest? {
+        return getDeleteRequest()
+    }
+
+    /// Returns a DELETE **URLRequest** based on the supplied name.
+    public static func deleteRequest(name: String) -> URLRequest? {
+        return getDeleteRequest(name: name)
+    }
+
+    /// Returns a DELETE **URLRequest** based on the name.
+    public func deleteRequestWithName() -> URLRequest? {
+        return getDeleteRequestWithName()
+    }
+}

--- a/JamfKit/Sources/Models/Computer/Computer.swift
+++ b/JamfKit/Sources/Models/Computer/Computer.swift
@@ -70,15 +70,13 @@ public final class Computer: NSObject, Requestable {
 
 extension Computer: Endpoint, Creatable {
 
-    // MARK: - Properties
+    // MARK: - Constants
 
-    public var endpoint: String {
-        return "computers"
-    }
+    public static var Endpoint: String = "computers"
 
     // MARK: - Functions
 
-    public func create(with key: String) -> URLRequest? {
-        return SessionManager.instance.createRequest(for: self, key: key, value: String(general.identifier))
+    public func create() -> URLRequest? {
+        return SessionManager.instance.createRequest(for: self, key: BaseObject.CodingKeys.identifier.rawValue, value: String(general.identifier))
     }
 }

--- a/JamfKit/Sources/Models/Computer/Computer.swift
+++ b/JamfKit/Sources/Models/Computer/Computer.swift
@@ -53,6 +53,18 @@ public final class Computer: NSObject, Requestable, Endpoint, Subset {
         }
     }
 
+    public init?(identifier: UInt, name: String) {
+        guard let general = ComputerGeneral(identifier: identifier, name: name) else {
+            return nil
+        }
+
+        self.general = general
+        location = ComputerLocation()
+        purchasing = ComputerPurchasing()
+
+        super.init()
+    }
+
     // MARK: - Functions
 
     public func toJSON() -> [String: Any] {

--- a/JamfKit/Sources/Models/Computer/Computer.swift
+++ b/JamfKit/Sources/Models/Computer/Computer.swift
@@ -2,14 +2,13 @@
 //  Computer.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
-
-import Foundation
 
 /// Represents a Jamf managed computer, contains the general / location / purchasing information about the hardware.
 @objc(JMFKComputer)
-public final class Computer: NSObject, Identifiable {
+public final class Computer: NSObject, Requestable {
 
     // MARK: - Constants
 
@@ -64,5 +63,22 @@ public final class Computer: NSObject, Identifiable {
         if let purchasing = purchasing { json[Computer.PurchasingKey] = purchasing.toJSON() }
 
         return json
+    }
+}
+
+// MARK: - Requestable
+
+extension Computer: Endpoint, Creatable {
+
+    // MARK: - Properties
+
+    public var endpoint: String {
+        return "computers"
+    }
+
+    // MARK: - Functions
+
+    public func create(with key: String) -> URLRequest? {
+        return SessionManager.instance.createRequest(for: self, key: key, value: String(general.identifier))
     }
 }

--- a/JamfKit/Sources/Models/Computer/Computer.swift
+++ b/JamfKit/Sources/Models/Computer/Computer.swift
@@ -8,10 +8,11 @@
 
 /// Represents a Jamf managed computer, contains the general / location / purchasing information about the hardware.
 @objc(JMFKComputer)
-public final class Computer: NSObject, Requestable {
+public final class Computer: NSObject, Requestable, Endpoint, Subset {
 
     // MARK: - Constants
 
+    public static let Endpoint: String = "computers"
     static let GeneralKey = "general"
     static let LocationKey = "location"
     static let PurchasingKey = "purchasing"
@@ -66,17 +67,86 @@ public final class Computer: NSObject, Requestable {
     }
 }
 
-// MARK: - Requestable
+// MARK: - Creatable
 
-extension Computer: Endpoint, Creatable {
-
-    // MARK: - Constants
-
-    public static var Endpoint: String = "computers"
-
-    // MARK: - Functions
+extension Computer: Creatable {
 
     public func create() -> URLRequest? {
         return SessionManager.instance.createRequest(for: self, key: BaseObject.CodingKeys.identifier.rawValue, value: String(general.identifier))
+    }
+}
+
+// MARK: - Readable
+
+extension Computer: Readable {
+
+    public func read() -> URLRequest? {
+        return Computer.read(identifier: String(general.identifier))
+    }
+
+    public func readWithName() -> URLRequest? {
+        return SessionManager.instance.readRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: general.name)
+    }
+
+    public func readWithUdid() -> URLRequest? {
+        return SessionManager.instance.readRequest(for: self, key: ComputerGeneral.UDIDKey, value: general.udid)
+    }
+
+    public func readWithSerialNumber() -> URLRequest? {
+        return SessionManager.instance.readRequest(for: self, key: ComputerGeneral.SerialNumberKey, value: general.serialNumber)
+    }
+
+    public func readWithMacAddress() -> URLRequest? {
+        return SessionManager.instance.readRequest(for: self, key: ComputerGeneral.MacAddressKey, value: general.macAddress)
+    }
+}
+
+// MARK: - Updatable
+
+extension Computer: Updatable {
+
+    public func update() -> URLRequest? {
+        return SessionManager.instance.updateRequest(for: self, key: BaseObject.CodingKeys.identifier.rawValue, value: String(general.identifier))
+    }
+
+    public func updateWithName() -> URLRequest? {
+        return SessionManager.instance.updateRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: general.name)
+    }
+
+    public func updateWithUdid() -> URLRequest? {
+        return SessionManager.instance.updateRequest(for: self, key: ComputerGeneral.UDIDKey, value: general.udid)
+    }
+
+    public func updateWithSerialNumber() -> URLRequest? {
+        return SessionManager.instance.updateRequest(for: self, key: ComputerGeneral.SerialNumberKey, value: general.serialNumber)
+    }
+
+    public func updateWithMacAddress() -> URLRequest? {
+        return SessionManager.instance.updateRequest(for: self, key: ComputerGeneral.MacAddressKey, value: general.macAddress)
+    }
+}
+
+// MARK: - Deletable
+
+extension Computer: Deletable {
+
+    public func delete() -> URLRequest? {
+        return Computer.delete(identifier: String(general.identifier))
+    }
+
+    public func deleteWithName() -> URLRequest? {
+        return SessionManager.instance.deleteRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: general.name)
+    }
+
+    public func deleteWithUdid() -> URLRequest? {
+        return SessionManager.instance.deleteRequest(for: self, key: ComputerGeneral.UDIDKey, value: general.udid)
+    }
+
+    public func deleteWithSerialNumber() -> URLRequest? {
+        return SessionManager.instance.deleteRequest(for: self, key: ComputerGeneral.SerialNumberKey, value: general.serialNumber)
+    }
+
+    public func deleteWithMacAddress() -> URLRequest? {
+        return SessionManager.instance.deleteRequest(for: self, key: ComputerGeneral.MacAddressKey, value: general.macAddress)
     }
 }

--- a/JamfKit/Sources/Models/Computer/Computer.swift
+++ b/JamfKit/Sources/Models/Computer/Computer.swift
@@ -83,7 +83,7 @@ public final class Computer: NSObject, Requestable, Endpoint, Subset {
 
 extension Computer: Creatable {
 
-    public func create() -> URLRequest? {
+    public func createRequest() -> URLRequest? {
         return SessionManager.instance.createRequest(for: self, key: BaseObject.CodingKeys.identifier.rawValue, value: String(general.identifier))
     }
 }
@@ -92,24 +92,56 @@ extension Computer: Creatable {
 
 extension Computer: Readable {
 
-    public func read() -> URLRequest? {
-        return Computer.read(identifier: String(general.identifier))
+    public static func readAllRequest() -> URLRequest? {
+        return getReadAllRequest()
     }
 
-    public func readWithName() -> URLRequest? {
-        return SessionManager.instance.readRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: general.name)
+    public static func readRequest(identifier: String) -> URLRequest? {
+        return getReadRequest(identifier: identifier)
     }
 
-    public func readWithUdid() -> URLRequest? {
-        return SessionManager.instance.readRequest(for: self, key: ComputerGeneral.UDIDKey, value: general.udid)
+    public func readRequest() -> URLRequest? {
+        return Computer.readRequest(identifier: String(general.identifier))
     }
 
-    public func readWithSerialNumber() -> URLRequest? {
-        return SessionManager.instance.readRequest(for: self, key: ComputerGeneral.SerialNumberKey, value: general.serialNumber)
+    /// Returns a GET **URLRequest** based on the supplied name.
+    public static func readRequest(name: String) -> URLRequest? {
+        return SessionManager.instance.readRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: name)
     }
 
-    public func readWithMacAddress() -> URLRequest? {
-        return SessionManager.instance.readRequest(for: self, key: ComputerGeneral.MacAddressKey, value: general.macAddress)
+    /// Returns a GET **URLRequest** based on the email.
+    public func readRequestWithName() -> URLRequest? {
+        return Computer.readRequest(name: general.name)
+    }
+
+    /// Returns a GET **URLRequest** based on the supplied udid.
+    public static func readRequest(udid: String) -> URLRequest? {
+        return SessionManager.instance.readRequest(for: self, key: ComputerGeneral.UDIDKey, value: udid)
+    }
+
+    /// Returns a GET **URLRequest** based on the supplied udid.
+    public func readRequestWithUdid() -> URLRequest? {
+        return Computer.readRequest(udid: general.udid)
+    }
+
+    /// Returns a GET **URLRequest** based on the supplied udid.
+    public static func readRequest(serialNumber: String) -> URLRequest? {
+        return SessionManager.instance.readRequest(for: self, key: ComputerGeneral.SerialNumberKey, value: serialNumber)
+    }
+
+    /// Returns a GET **URLRequest** based on the supplied serial number.
+    public func readRequestWithSerialNumber() -> URLRequest? {
+        return Computer.readRequest(serialNumber: general.serialNumber)
+    }
+
+    /// Returns a GET **URLRequest** based on the supplied udid.
+    public static func readRequest(macAddress: String) -> URLRequest? {
+        return SessionManager.instance.readRequest(for: self, key: ComputerGeneral.MacAddressKey, value: macAddress)
+    }
+
+    /// Returns a GET **URLRequest** based on the supplied mac address.
+    public func readRequestWithMacAddress() -> URLRequest? {
+        return Computer.readRequest(macAddress: general.macAddress)
     }
 }
 
@@ -117,23 +149,27 @@ extension Computer: Readable {
 
 extension Computer: Updatable {
 
-    public func update() -> URLRequest? {
+    public func updateRequest() -> URLRequest? {
         return SessionManager.instance.updateRequest(for: self, key: BaseObject.CodingKeys.identifier.rawValue, value: String(general.identifier))
     }
 
-    public func updateWithName() -> URLRequest? {
+    /// Returns a PUT **URLRequest** based on the name.
+    public func updateRequestWithName() -> URLRequest? {
         return SessionManager.instance.updateRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: general.name)
     }
 
-    public func updateWithUdid() -> URLRequest? {
+    /// Returns a PUT **URLRequest** based on the udid.
+    public func updateRequestWithUdid() -> URLRequest? {
         return SessionManager.instance.updateRequest(for: self, key: ComputerGeneral.UDIDKey, value: general.udid)
     }
 
-    public func updateWithSerialNumber() -> URLRequest? {
+    /// Returns a PUT **URLRequest** based on the serial number.
+    public func updateRequestWithSerialNumber() -> URLRequest? {
         return SessionManager.instance.updateRequest(for: self, key: ComputerGeneral.SerialNumberKey, value: general.serialNumber)
     }
 
-    public func updateWithMacAddress() -> URLRequest? {
+    /// Returns a PUT **URLRequest** based on the mac address.
+    public func updateRequestWithMacAddress() -> URLRequest? {
         return SessionManager.instance.updateRequest(for: self, key: ComputerGeneral.MacAddressKey, value: general.macAddress)
     }
 }
@@ -142,23 +178,51 @@ extension Computer: Updatable {
 
 extension Computer: Deletable {
 
-    public func delete() -> URLRequest? {
-        return Computer.delete(identifier: String(general.identifier))
+    public static func deleteRequest(identifier: String) -> URLRequest? {
+        return getDeleteRequest(identifier: identifier)
     }
 
-    public func deleteWithName() -> URLRequest? {
-        return SessionManager.instance.deleteRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: general.name)
+    public func deleteRequest() -> URLRequest? {
+        return Computer.deleteRequest(identifier: String(general.identifier))
     }
 
-    public func deleteWithUdid() -> URLRequest? {
-        return SessionManager.instance.deleteRequest(for: self, key: ComputerGeneral.UDIDKey, value: general.udid)
+    /// Returns a DELETE **URLRequest** based on the supplied name.
+    public static func deleteRequest(name: String) -> URLRequest? {
+        return SessionManager.instance.deleteRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: name)
     }
 
-    public func deleteWithSerialNumber() -> URLRequest? {
-        return SessionManager.instance.deleteRequest(for: self, key: ComputerGeneral.SerialNumberKey, value: general.serialNumber)
+    /// Returns a DELETE **URLRequest** based on the name.
+    public func deleteRequestWithName() -> URLRequest? {
+        return Computer.deleteRequest(name: general.name)
     }
 
-    public func deleteWithMacAddress() -> URLRequest? {
-        return SessionManager.instance.deleteRequest(for: self, key: ComputerGeneral.MacAddressKey, value: general.macAddress)
+    /// Returns a DELETE **URLRequest** based on the supplied udid.
+    public static func deleteRequest(udid: String) -> URLRequest? {
+        return SessionManager.instance.deleteRequest(for: self, key: ComputerGeneral.UDIDKey, value: udid)
+    }
+
+    /// Returns a DELETE **URLRequest** based on the udid.
+    public func deleteRequestWithUdid() -> URLRequest? {
+        return Computer.deleteRequest(udid: general.udid)
+    }
+
+    /// Returns a DELETE **URLRequest** based on the supplied serial number.
+    public static func deleteRequest(serialNumber: String) -> URLRequest? {
+        return SessionManager.instance.deleteRequest(for: self, key: ComputerGeneral.SerialNumberKey, value: serialNumber)
+    }
+
+    /// Returns a DELETE **URLRequest** based on the serial number.
+    public func deleteRequestWithSerialNumber() -> URLRequest? {
+        return Computer.deleteRequest(serialNumber: general.serialNumber)
+    }
+
+    /// Returns a DELETE **URLRequest** based on the supplied mac address.
+    public static func deleteRequest(macAddress: String) -> URLRequest? {
+        return SessionManager.instance.deleteRequest(for: self, key: ComputerGeneral.MacAddressKey, value: macAddress)
+    }
+
+    /// Returns a DELETE **URLRequest** based on the mac address.
+    public func deleteRequestWithMacAddress() -> URLRequest? {
+        return Computer.deleteRequest(macAddress: general.macAddress)
     }
 }

--- a/JamfKit/Sources/Models/Computer/ComputerGeneral.swift
+++ b/JamfKit/Sources/Models/Computer/ComputerGeneral.swift
@@ -2,10 +2,9 @@
 //  ComputerGeneral.swift
 //  JamfKit
 //
-//  Copyright © 2017 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
-
-import Foundation
 
 @objc(JMFKComputerGeneral)
 public final class ComputerGeneral: BaseObject {

--- a/JamfKit/Sources/Models/Computer/ComputerGeneral.swift
+++ b/JamfKit/Sources/Models/Computer/ComputerGeneral.swift
@@ -40,46 +40,46 @@ public final class ComputerGeneral: BaseObject {
     // MARK: - Properties
 
     @objc
-    public var macAddress: String
+    public var macAddress = ""
 
     @objc
-    public var alternativeMacAddress: String
+    public var alternativeMacAddress = ""
 
     @objc
-    public var ipAddress: String
+    public var ipAddress = ""
 
     @objc
-    public var lastReportedIpAddress: String
+    public var lastReportedIpAddress = ""
 
     @objc
-    public var serialNumber: String
+    public var serialNumber = ""
 
     @objc
-    public var udid: String
+    public var udid = ""
 
     @objc
-    public var jamfVersion: String
+    public var jamfVersion = ""
 
     @objc
-    public var platform: String
+    public var platform = ""
 
     @objc
-    public var barcode1: String
+    public var barcode1 = ""
 
     @objc
-    public var barcode2: String
+    public var barcode2 = ""
 
     @objc
-    public var assetTag: String
+    public var assetTag = ""
 
     @objc
     public var remoteManagement: ComputerRemoteManagement?
 
     @objc
-    public var isMdmCapable: Bool
+    public var isMdmCapable = false
 
     @objc
-    public var mdmCapableUsers: [String]
+    public var mdmCapableUsers = [String]()
 
     @objc
     public var reportDate: PreciseDate?
@@ -97,19 +97,19 @@ public final class ComputerGeneral: BaseObject {
     public var lastEnrolledDate: PreciseDate?
 
     @objc
-    public var distributionPoint: String
+    public var distributionPoint = ""
 
     @objc
-    public var sus: String
+    public var sus = ""
 
     @objc
-    public var netbootServer: String
+    public var netbootServer = ""
 
     @objc
     public var site: Site?
 
     @objc
-    public var isITunesStoreAcccountActivated: Bool
+    public var isITunesStoreAcccountActivated = false
 
     // MARK: - Initialization
 
@@ -140,6 +140,12 @@ public final class ComputerGeneral: BaseObject {
         isITunesStoreAcccountActivated = json[ComputerGeneral.ItunesStoreAccountIsActiveKey] as? Bool ?? false
 
         super.init(json: json)
+    }
+
+    public override init?(identifier: UInt, name: String) {
+        remoteManagement = ComputerRemoteManagement()
+
+        super.init(identifier: identifier, name: name)
     }
 
     // MARK: - Functions

--- a/JamfKit/Sources/Models/Computer/ComputerLocation.swift
+++ b/JamfKit/Sources/Models/Computer/ComputerLocation.swift
@@ -2,13 +2,12 @@
 //  Location.swift
 //  JamfKit
 //
-//  Copyright © 2017 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
-import Foundation
-
 @objc(JMFKComputerLocation)
-public final class ComputerLocation: NSObject, Identifiable {
+public final class ComputerLocation: NSObject, Requestable {
 
     // MARK: - Constants
 

--- a/JamfKit/Sources/Models/Computer/ComputerLocation.swift
+++ b/JamfKit/Sources/Models/Computer/ComputerLocation.swift
@@ -23,28 +23,28 @@ public final class ComputerLocation: NSObject, Requestable {
     // MARK: - Properties
 
     @objc
-    public var username: String
+    public var username = ""
 
     @objc
-    public var realName: String
+    public var realName = ""
 
     @objc
-    public var emailAddress: String
+    public var emailAddress = ""
 
     @objc
-    public var position: String
+    public var position = ""
 
     @objc
-    public var phoneNumber: String
+    public var phoneNumber = ""
 
     @objc
-    public var department: String
+    public var department = ""
 
     @objc
-    public var building: String
+    public var building = ""
 
     @objc
-    public var room: UInt
+    public var room: UInt = 0
 
     // MARK: - Initialization
 
@@ -57,6 +57,10 @@ public final class ComputerLocation: NSObject, Requestable {
         department = json[ComputerLocation.DepartementKey] as? String ?? ""
         building = json[ComputerLocation.BuildingKey] as? String ?? ""
         room = json[ComputerLocation.RoomKey] as? UInt ?? 0
+    }
+
+    public override init() {
+        super.init()
     }
 
     // MARK: - Functions

--- a/JamfKit/Sources/Models/Computer/ComputerPurchasing.swift
+++ b/JamfKit/Sources/Models/Computer/ComputerPurchasing.swift
@@ -2,13 +2,12 @@
 //  Purchasing.swift
 //  JamfKit
 //
-//  Copyright © 2017 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
-import Foundation
-
 @objc(JMFKComputerPurchasing)
-public final class ComputerPurchasing: NSObject, Identifiable {
+public final class ComputerPurchasing: NSObject, Requestable {
 
     // MARK: - Constants
 

--- a/JamfKit/Sources/Models/Computer/ComputerPurchasing.swift
+++ b/JamfKit/Sources/Models/Computer/ComputerPurchasing.swift
@@ -27,28 +27,28 @@ public final class ComputerPurchasing: NSObject, Requestable {
     // MARK: - Properties
 
     @objc
-    public var isPurchased: Bool
+    public var isPurchased = false
 
     @objc
-    public var isLeased: Bool
+    public var isLeased = false
 
     @objc
-    public var poNumber: String
+    public var poNumber = ""
 
     @objc
-    public var vendor: String
+    public var vendor = ""
 
     @objc
-    public var appleCareIdentifier: String
+    public var appleCareIdentifier = ""
 
     @objc
-    public var purchasePrice: String
+    public var purchasePrice = ""
 
     @objc
-    public var purchasingAccount: String
+    public var purchasingAccount = ""
 
     @objc
-    public var purchasingContact: String
+    public var purchasingContact = ""
 
     @objc
     public var poDate: PreciseDate?
@@ -60,7 +60,7 @@ public final class ComputerPurchasing: NSObject, Requestable {
     public var leaseExpires: PreciseDate?
 
     @objc
-    public var lifeExpectancy: UInt
+    public var lifeExpectancy: UInt = 0
 
     // MARK: - Initialization
 
@@ -77,6 +77,10 @@ public final class ComputerPurchasing: NSObject, Requestable {
         warrantyExpires = PreciseDate(json: json, node: ComputerPurchasing.WarrantyExpiresKey)
         leaseExpires = PreciseDate(json: json, node: ComputerPurchasing.LeaseExpiresKey)
         lifeExpectancy = json[ComputerPurchasing.LifeExpectancyKey] as? UInt ?? 0
+    }
+
+    public override init() {
+        super.init()
     }
 
     // MARK: - Functions

--- a/JamfKit/Sources/Models/Computer/ComputerRemoteManagement.swift
+++ b/JamfKit/Sources/Models/Computer/ComputerRemoteManagement.swift
@@ -2,13 +2,12 @@
 //  ComputerRemoteManagement.swift
 //  JamfKit
 //
-//  Copyright © 2017 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
-import Foundation
-
 @objc(JMFKComputerRemoteManagement)
-public final class ComputerRemoteManagement: NSObject, Identifiable {
+public final class ComputerRemoteManagement: NSObject, Requestable {
 
     // MARK: - Constants
 

--- a/JamfKit/Sources/Models/Computer/ComputerRemoteManagement.swift
+++ b/JamfKit/Sources/Models/Computer/ComputerRemoteManagement.swift
@@ -17,16 +17,20 @@ public final class ComputerRemoteManagement: NSObject, Requestable {
     // MARK: - Properties
 
     @objc
-    public var isManaged: Bool
+    public var isManaged = false
 
     @objc
-    public var managementUsername: String
+    public var managementUsername = ""
 
     // MARK: - Initialization
 
     public init?(json: [String: Any], node: String = "") {
         isManaged = json[ComputerRemoteManagement.ManagedKey] as? Bool ?? false
         managementUsername = json[ComputerRemoteManagement.ManagementUsernameKey] as? String ?? ""
+    }
+
+    public override init() {
+        super.init()
     }
 
     // MARK: - Functions

--- a/JamfKit/Sources/Models/ComputerCommand/ComputerCommand.swift
+++ b/JamfKit/Sources/Models/ComputerCommand/ComputerCommand.swift
@@ -2,14 +2,13 @@
 //  ComputerCommand.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
-
-import Foundation
 
 /// Represents a logical command that can be executed on any hardware element manageg by Jamf.
 @objc(JMFKComputerCommand)
-public final class ComputerCommand: NSObject, Identifiable {
+public final class ComputerCommand: NSObject, Requestable {
 
     // MARK: - Constants
 
@@ -67,5 +66,22 @@ public final class ComputerCommand: NSObject, Identifiable {
         }
 
         return json
+    }
+}
+
+// MARK: - Requestable
+
+extension ComputerCommand: Endpoint, Creatable {
+
+    // MARK: - Properties
+
+    public var endpoint: String {
+        return "computercommands"
+    }
+
+    // MARK: - Functions
+
+    public func create(with key: String) -> URLRequest? {
+        return SessionManager.instance.createRequest(for: self, key: key, value: general.command)
     }
 }

--- a/JamfKit/Sources/Models/ComputerCommand/ComputerCommand.swift
+++ b/JamfKit/Sources/Models/ComputerCommand/ComputerCommand.swift
@@ -8,10 +8,11 @@
 
 /// Represents a logical command that can be executed on any hardware element manageg by Jamf.
 @objc(JMFKComputerCommand)
-public final class ComputerCommand: NSObject, Requestable {
+public final class ComputerCommand: NSObject, Requestable, Endpoint, Subset {
 
     // MARK: - Constants
 
+    public static let Endpoint: String = "computercommands"
     static let GeneralKey = "general"
     static let ComputersKey = "computers"
 
@@ -69,17 +70,24 @@ public final class ComputerCommand: NSObject, Requestable {
     }
 }
 
-// MARK: - Requestable
+// MARK: - Creatable
 
-extension ComputerCommand: Endpoint, Creatable {
-
-    // MARK: - Constants
-
-    public static var Endpoint: String = "computercommands"
-
-    // MARK: - Functions
+extension ComputerCommand: Creatable {
 
     public func create() -> URLRequest? {
         return SessionManager.instance.createRequest(for: self, key: ComputerCommandGeneral.CommandKey, value: general.command)
+    }
+}
+
+// MARK: - Readable
+
+extension ComputerCommand: Readable {
+
+    public static func read(identifier: String) -> URLRequest? {
+        return nil
+    }
+
+    public func read() -> URLRequest? {
+        return nil
     }
 }

--- a/JamfKit/Sources/Models/ComputerCommand/ComputerCommand.swift
+++ b/JamfKit/Sources/Models/ComputerCommand/ComputerCommand.swift
@@ -22,7 +22,7 @@ public final class ComputerCommand: NSObject, Requestable, Endpoint, Subset {
     public var general: ComputerCommandGeneral
 
     @objc
-    public var computers: [UInt]
+    public var computers = [UInt]()
 
     public override var description: String {
         return "[\(String(describing: type(of: self)))][\(general.command)]"
@@ -45,6 +45,14 @@ public final class ComputerCommand: NSObject, Requestable, Endpoint, Subset {
         } else {
             computers = [UInt]()
         }
+    }
+
+    public init?(command: String, passcode: UInt) {
+        guard let general = ComputerCommandGeneral(command: command, passcode: passcode) else {
+            return nil
+        }
+
+        self.general = general
     }
 
     // MARK: - Functions

--- a/JamfKit/Sources/Models/ComputerCommand/ComputerCommand.swift
+++ b/JamfKit/Sources/Models/ComputerCommand/ComputerCommand.swift
@@ -82,7 +82,7 @@ public final class ComputerCommand: NSObject, Requestable, Endpoint, Subset {
 
 extension ComputerCommand: Creatable {
 
-    public func create() -> URLRequest? {
+    public func createRequest() -> URLRequest? {
         return SessionManager.instance.createRequest(for: self, key: ComputerCommandGeneral.CommandKey, value: general.command)
     }
 }
@@ -91,11 +91,15 @@ extension ComputerCommand: Creatable {
 
 extension ComputerCommand: Readable {
 
-    public static func read(identifier: String) -> URLRequest? {
+    public static func readAllRequest() -> URLRequest? {
+        return getReadAllRequest()
+    }
+
+    public static func readRequest(identifier: String) -> URLRequest? {
         return nil
     }
 
-    public func read() -> URLRequest? {
+    public func readRequest() -> URLRequest? {
         return nil
     }
 }

--- a/JamfKit/Sources/Models/ComputerCommand/ComputerCommand.swift
+++ b/JamfKit/Sources/Models/ComputerCommand/ComputerCommand.swift
@@ -73,15 +73,13 @@ public final class ComputerCommand: NSObject, Requestable {
 
 extension ComputerCommand: Endpoint, Creatable {
 
-    // MARK: - Properties
+    // MARK: - Constants
 
-    public var endpoint: String {
-        return "computercommands"
-    }
+    public static var Endpoint: String = "computercommands"
 
     // MARK: - Functions
 
-    public func create(with key: String) -> URLRequest? {
-        return SessionManager.instance.createRequest(for: self, key: key, value: general.command)
+    public func create() -> URLRequest? {
+        return SessionManager.instance.createRequest(for: self, key: ComputerCommandGeneral.CommandKey, value: general.command)
     }
 }

--- a/JamfKit/Sources/Models/ComputerCommand/ComputerCommandGeneral.swift
+++ b/JamfKit/Sources/Models/ComputerCommand/ComputerCommandGeneral.swift
@@ -2,13 +2,12 @@
 //  ComputerCommandGeneral.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
-import Foundation
-
 @objc(JMFKComputerCommandGeneral)
-public final class ComputerCommandGeneral: NSObject, Identifiable {
+public final class ComputerCommandGeneral: NSObject, Requestable {
 
     // MARK: - Constants
 

--- a/JamfKit/Sources/Models/ComputerCommand/ComputerCommandGeneral.swift
+++ b/JamfKit/Sources/Models/ComputerCommand/ComputerCommandGeneral.swift
@@ -17,10 +17,10 @@ public final class ComputerCommandGeneral: NSObject, Requestable {
     // MARK: - Properties
 
     @objc
-    public var command: String
+    public var command = ""
 
     @objc
-    public var passcode: UInt
+    public var passcode: UInt = 0
 
     // MARK: - Initialization
 
@@ -30,6 +30,15 @@ public final class ComputerCommandGeneral: NSObject, Requestable {
             let passcode = json[ComputerCommandGeneral.PasscodeKey] as? UInt
             else {
                 return nil
+        }
+
+        self.command = command
+        self.passcode = passcode
+    }
+
+    public init?(command: String, passcode: UInt) {
+        guard !command.isEmpty, passcode > 0 else {
+            return nil
         }
 
         self.command = command

--- a/JamfKit/Sources/Models/ComputerConfiguration/ComputerConfiguration.swift
+++ b/JamfKit/Sources/Models/ComputerConfiguration/ComputerConfiguration.swift
@@ -37,6 +37,14 @@ public final class ComputerConfiguration: NSObject, Requestable, Endpoint, Subse
         self.general = general
     }
 
+    public init?(identifier: UInt, name: String) {
+        guard let general = ComputerConfigurationGeneral(identifier: identifier, name: name) else {
+            return nil
+        }
+
+        self.general = general
+    }
+
     // MARK: - Functions
 
     public func toJSON() -> [String: Any] {

--- a/JamfKit/Sources/Models/ComputerConfiguration/ComputerConfiguration.swift
+++ b/JamfKit/Sources/Models/ComputerConfiguration/ComputerConfiguration.swift
@@ -51,15 +51,13 @@ public final class ComputerConfiguration: NSObject, Requestable {
 
 extension ComputerConfiguration: Endpoint, Creatable {
 
-    // MARK: - Properties
+    // MARK: - Constants
 
-    public var endpoint: String {
-        return "computerconfigurations"
-    }
+    public static var Endpoint: String = "computerconfigurations"
 
     // MARK: - Functions
 
-    public func create(with key: String) -> URLRequest? {
-        return SessionManager.instance.createRequest(for: self, key: key, value: String(general.identifier))
+    public func create() -> URLRequest? {
+        return SessionManager.instance.createRequest(for: self, key: BaseObject.CodingKeys.identifier.rawValue, value: String(general.identifier))
     }
 }

--- a/JamfKit/Sources/Models/ComputerConfiguration/ComputerConfiguration.swift
+++ b/JamfKit/Sources/Models/ComputerConfiguration/ComputerConfiguration.swift
@@ -2,14 +2,13 @@
 //  ComputerConfiguration.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
-
-import Foundation
 
 /// Represents a logical configuration that can be applied to any hardware element managed by Jamf.
 @objc(JMFKComputerConfiguration)
-public final class ComputerConfiguration: NSObject, Identifiable {
+public final class ComputerConfiguration: NSObject, Requestable {
 
     // MARK: - Constants
 
@@ -45,5 +44,22 @@ public final class ComputerConfiguration: NSObject, Identifiable {
         json[ComputerConfiguration.GeneralKey] = general.toJSON()
 
         return json
+    }
+}
+
+// MARK: - Requestable
+
+extension ComputerConfiguration: Endpoint, Creatable {
+
+    // MARK: - Properties
+
+    public var endpoint: String {
+        return "computerconfigurations"
+    }
+
+    // MARK: - Functions
+
+    public func create(with key: String) -> URLRequest? {
+        return SessionManager.instance.createRequest(for: self, key: key, value: String(general.identifier))
     }
 }

--- a/JamfKit/Sources/Models/ComputerConfiguration/ComputerConfiguration.swift
+++ b/JamfKit/Sources/Models/ComputerConfiguration/ComputerConfiguration.swift
@@ -8,10 +8,11 @@
 
 /// Represents a logical configuration that can be applied to any hardware element managed by Jamf.
 @objc(JMFKComputerConfiguration)
-public final class ComputerConfiguration: NSObject, Requestable {
+public final class ComputerConfiguration: NSObject, Requestable, Endpoint, Subset {
 
     // MARK: - Constants
 
+    public static let Endpoint: String = "computerconfigurations"
     static let GeneralKey = "general"
 
     // MARK: - Properties
@@ -47,17 +48,50 @@ public final class ComputerConfiguration: NSObject, Requestable {
     }
 }
 
-// MARK: - Requestable
+// MARK: - Creatable
 
-extension ComputerConfiguration: Endpoint, Creatable {
-
-    // MARK: - Constants
-
-    public static var Endpoint: String = "computerconfigurations"
-
-    // MARK: - Functions
+extension ComputerConfiguration: Creatable {
 
     public func create() -> URLRequest? {
         return SessionManager.instance.createRequest(for: self, key: BaseObject.CodingKeys.identifier.rawValue, value: String(general.identifier))
+    }
+}
+
+// MARK: - Readable
+
+extension ComputerConfiguration: Readable {
+
+    public func read() -> URLRequest? {
+        return SessionManager.instance.readRequest(for: self, key: BaseObject.CodingKeys.identifier.rawValue, value: String(general.identifier))
+    }
+
+    public func readWithName() -> URLRequest? {
+        return SessionManager.instance.readRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: general.name)
+    }
+}
+
+// MARK: - Updatable
+
+extension ComputerConfiguration: Updatable {
+
+    public func update() -> URLRequest? {
+        return SessionManager.instance.updateRequest(for: self, key: BaseObject.CodingKeys.identifier.rawValue, value: String(general.identifier))
+    }
+
+    public func updateWithName() -> URLRequest? {
+        return SessionManager.instance.updateRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: general.name)
+    }
+}
+
+// MARK: - Deletable
+
+extension ComputerConfiguration: Deletable {
+
+    public func delete() -> URLRequest? {
+        return ComputerConfiguration.delete(identifier: String(general.identifier))
+    }
+
+    public func deleteWithName() -> URLRequest? {
+        return SessionManager.instance.deleteRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: general.name)
     }
 }

--- a/JamfKit/Sources/Models/ComputerConfiguration/ComputerConfiguration.swift
+++ b/JamfKit/Sources/Models/ComputerConfiguration/ComputerConfiguration.swift
@@ -60,7 +60,7 @@ public final class ComputerConfiguration: NSObject, Requestable, Endpoint, Subse
 
 extension ComputerConfiguration: Creatable {
 
-    public func create() -> URLRequest? {
+    public func createRequest() -> URLRequest? {
         return SessionManager.instance.createRequest(for: self, key: BaseObject.CodingKeys.identifier.rawValue, value: String(general.identifier))
     }
 }
@@ -69,11 +69,19 @@ extension ComputerConfiguration: Creatable {
 
 extension ComputerConfiguration: Readable {
 
-    public func read() -> URLRequest? {
+    public static func readAllRequest() -> URLRequest? {
+        return getReadAllRequest()
+    }
+
+    public static func readRequest(identifier: String) -> URLRequest? {
+        return getReadRequest(identifier: identifier)
+    }
+
+    public func readRequest() -> URLRequest? {
         return SessionManager.instance.readRequest(for: self, key: BaseObject.CodingKeys.identifier.rawValue, value: String(general.identifier))
     }
 
-    public func readWithName() -> URLRequest? {
+    public func readRequestWithName() -> URLRequest? {
         return SessionManager.instance.readRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: general.name)
     }
 }
@@ -82,11 +90,12 @@ extension ComputerConfiguration: Readable {
 
 extension ComputerConfiguration: Updatable {
 
-    public func update() -> URLRequest? {
+    public func updateRequest() -> URLRequest? {
         return SessionManager.instance.updateRequest(for: self, key: BaseObject.CodingKeys.identifier.rawValue, value: String(general.identifier))
     }
 
-    public func updateWithName() -> URLRequest? {
+    /// Returns a PUT **URLRequest** based on the name.
+    public func updateRequestWithName() -> URLRequest? {
         return SessionManager.instance.updateRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: general.name)
     }
 }
@@ -95,11 +104,21 @@ extension ComputerConfiguration: Updatable {
 
 extension ComputerConfiguration: Deletable {
 
-    public func delete() -> URLRequest? {
-        return ComputerConfiguration.delete(identifier: String(general.identifier))
+    public static func deleteRequest(identifier: String) -> URLRequest? {
+        return getDeleteRequest(identifier: identifier)
     }
 
-    public func deleteWithName() -> URLRequest? {
-        return SessionManager.instance.deleteRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: general.name)
+    public func deleteRequest() -> URLRequest? {
+        return ComputerConfiguration.deleteRequest(identifier: String(general.identifier))
+    }
+
+    /// Returns a DELETE **URLRequest** based on the supplied name.
+    public static func deleteRequest(name: String) -> URLRequest? {
+        return getDeleteRequest(name: name)
+    }
+
+    /// Returns a DELETE **URLRequest** based on the name.
+    public func deleteRequestWithName() -> URLRequest? {
+        return ComputerConfiguration.deleteRequest(name: general.name)
     }
 }

--- a/JamfKit/Sources/Models/ComputerConfiguration/ComputerConfigurationGeneral.swift
+++ b/JamfKit/Sources/Models/ComputerConfiguration/ComputerConfigurationGeneral.swift
@@ -25,34 +25,34 @@ public final class ComputerConfigurationGeneral: BaseObject {
     // MARK: - Properties
 
     @objc
-    public var desc: String
+    public var desc = ""
 
     @objc
-    public var type: String
+    public var type = ""
 
     @objc
-    public var parent: String
+    public var parent = ""
 
     @objc
-    public var packages: [Package]
+    public var packages = [Package]()
 
     @objc
-    public var scripts: [Script]
+    public var scripts = [Script]()
 
     @objc
-    public var printers: [Printer]
+    public var printers = [Printer]()
 
     @objc
-    public var directoryBindings: [DirectoryBinding]
+    public var directoryBindings = [DirectoryBinding]()
 
     @objc
     public var management: ComputerConfigurationManagement?
 
     @objc
-    public var homepage: String
+    public var homepage = ""
 
     @objc
-    public var partitions: [Partition]
+    public var partitions = [Partition]()
 
     // MARK: - Initialization
 
@@ -69,6 +69,10 @@ public final class ComputerConfigurationGeneral: BaseObject {
         partitions = ComputerConfigurationGeneral.parsePartitions(json: json)
 
         super.init(json: json)
+    }
+
+    public override init?(identifier: UInt, name: String) {
+        super.init(identifier: identifier, name: name)
     }
 
     // MARK: - Functions

--- a/JamfKit/Sources/Models/ComputerConfiguration/ComputerConfigurationGeneral.swift
+++ b/JamfKit/Sources/Models/ComputerConfiguration/ComputerConfigurationGeneral.swift
@@ -2,10 +2,9 @@
 //  ComputerConfigurationGeneral.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
-
-import Foundation
 
 @objc(JMFKComputerConfigurationGeneral)
 public final class ComputerConfigurationGeneral: BaseObject {

--- a/JamfKit/Sources/Models/ComputerConfiguration/ComputerConfigurationManagement.swift
+++ b/JamfKit/Sources/Models/ComputerConfiguration/ComputerConfigurationManagement.swift
@@ -2,13 +2,12 @@
 //  ComputerConfigurationManagement.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
-import Foundation
-
 @objc(JMFKComputerConfigurationManagement)
-public final class ComputerConfigurationManagement: NSObject, Identifiable {
+public final class ComputerConfigurationManagement: NSObject, Requestable {
 
     // MARK: - Constants
 

--- a/JamfKit/Sources/Models/ComputerGroup/ComputerGroup.swift
+++ b/JamfKit/Sources/Models/ComputerGroup/ComputerGroup.swift
@@ -2,10 +2,9 @@
 //  ComputerGroup.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
-
-import Foundation
 
 /// Represents a group of computers managed by Jamf, contains grouping information.
 @objc(JMFKComputerGroup)
@@ -44,5 +43,16 @@ public final class ComputerGroup: HardwareGroup {
 
     private static func parseComputers(json: [String: Any]) -> [ComputerGeneral] {
         return BaseObject.parseElements(from: json, nodeKey: ComputerGroup.ComputersKey, singleNodeKey: "computer")
+    }
+}
+
+// MARK: - Requestable
+
+extension ComputerGroup: Endpoint, Creatable {
+
+    // MARK: - Properties
+
+    public var endpoint: String {
+        return "computergroups"
     }
 }

--- a/JamfKit/Sources/Models/ComputerGroup/ComputerGroup.swift
+++ b/JamfKit/Sources/Models/ComputerGroup/ComputerGroup.swift
@@ -50,9 +50,7 @@ public final class ComputerGroup: HardwareGroup {
 
 extension ComputerGroup: Endpoint, Creatable {
 
-    // MARK: - Properties
+    // MARK: - Constants
 
-    public var endpoint: String {
-        return "computergroups"
-    }
+    public static var Endpoint: String = "computergroups"
 }

--- a/JamfKit/Sources/Models/ComputerGroup/ComputerGroup.swift
+++ b/JamfKit/Sources/Models/ComputerGroup/ComputerGroup.swift
@@ -55,11 +55,71 @@ public final class ComputerGroup: HardwareGroup, Endpoint {
 
 extension ComputerGroup: Creatable {
 
-    public func create() -> URLRequest? {
-        return self.createRequest()
+    public func createRequest() -> URLRequest? {
+        return getCreateRequest()
     }
 }
 
-// MARK: - Protocols
+// MARK: - Readable
 
-extension ComputerGroup: Readable, Updatable, Deletable { }
+extension ComputerGroup: Readable {
+
+    public static func readAllRequest() -> URLRequest? {
+        return getReadAllRequest()
+    }
+
+    public static func readRequest(identifier: String) -> URLRequest? {
+        return getReadRequest(identifier: identifier)
+    }
+
+    public func readRequest() -> URLRequest? {
+        return getReadRequest()
+    }
+
+    /// Returns a GET **URLRequest** based on the supplied name.
+    public static func readRequest(name: String) -> URLRequest? {
+        return getReadRequest(name: name)
+    }
+
+    /// Returns a GET **URLRequest** based on the email.
+    public func readRequestWithName() -> URLRequest? {
+        return getReadRequestWithName()
+    }
+}
+
+// MARK: - Updatable
+
+extension ComputerGroup: Updatable {
+
+    public func updateRequest() -> URLRequest? {
+        return getUpdateRequest()
+    }
+
+    /// Returns a PUT **URLRequest** based on the name.
+    public func updateRequestWithName() -> URLRequest? {
+        return getUpdateRequestWithName()
+    }
+}
+
+// MARK: - Deletable
+
+extension ComputerGroup: Deletable {
+
+    public static func deleteRequest(identifier: String) -> URLRequest? {
+        return getDeleteRequest(identifier: identifier)
+    }
+
+    public func deleteRequest() -> URLRequest? {
+        return getDeleteRequest()
+    }
+
+    /// Returns a DELETE **URLRequest** based on the supplied name.
+    public static func deleteRequest(name: String) -> URLRequest? {
+        return getDeleteRequest(name: name)
+    }
+
+    /// Returns a DELETE **URLRequest** based on the name.
+    public func deleteRequestWithName() -> URLRequest? {
+        return getDeleteRequestWithName()
+    }
+}

--- a/JamfKit/Sources/Models/ComputerGroup/ComputerGroup.swift
+++ b/JamfKit/Sources/Models/ComputerGroup/ComputerGroup.swift
@@ -18,7 +18,7 @@ public final class ComputerGroup: HardwareGroup, Endpoint {
     // MARK: - Properties
 
     @objc
-    public var computers: [ComputerGeneral]
+    public var computers = [ComputerGeneral]()
 
     // MARK: - Initialization
 
@@ -26,6 +26,10 @@ public final class ComputerGroup: HardwareGroup, Endpoint {
         computers = ComputerGroup.parseComputers(json: json)
 
         super.init(json: json)
+    }
+
+    public override init?(identifier: UInt, name: String) {
+        super.init(identifier: identifier, name: name)
     }
 
     // MARK: - Functions

--- a/JamfKit/Sources/Models/ComputerGroup/ComputerGroup.swift
+++ b/JamfKit/Sources/Models/ComputerGroup/ComputerGroup.swift
@@ -51,6 +51,15 @@ public final class ComputerGroup: HardwareGroup, Endpoint {
     }
 }
 
+// MARK: - Creatable
+
+extension ComputerGroup: Creatable {
+
+    public func create() -> URLRequest? {
+        return self.createRequest()
+    }
+}
+
 // MARK: - Protocols
 
-extension ComputerGroup: Creatable, Readable, Updatable, Deletable { }
+extension ComputerGroup: Readable, Updatable, Deletable { }

--- a/JamfKit/Sources/Models/ComputerGroup/ComputerGroup.swift
+++ b/JamfKit/Sources/Models/ComputerGroup/ComputerGroup.swift
@@ -8,10 +8,11 @@
 
 /// Represents a group of computers managed by Jamf, contains grouping information.
 @objc(JMFKComputerGroup)
-public final class ComputerGroup: HardwareGroup {
+public final class ComputerGroup: HardwareGroup, Endpoint {
 
     // MARK: - Constants
 
+    public static let Endpoint: String = "computergroups"
     static let ComputersKey = "computers"
 
     // MARK: - Properties
@@ -46,11 +47,6 @@ public final class ComputerGroup: HardwareGroup {
     }
 }
 
-// MARK: - Requestable
+// MARK: - Protocols
 
-extension ComputerGroup: Endpoint, Creatable {
-
-    // MARK: - Constants
-
-    public static var Endpoint: String = "computergroups"
-}
+extension ComputerGroup: Creatable, Readable, Updatable, Deletable { }

--- a/JamfKit/Sources/Models/Department.swift
+++ b/JamfKit/Sources/Models/Department.swift
@@ -15,6 +15,15 @@ public final class Department: BaseObject, Endpoint {
     public static let Endpoint: String = "departments"
 }
 
+// MARK: - Creatable
+
+extension Department: Creatable {
+
+    public func create() -> URLRequest? {
+        return self.createRequest()
+    }
+}
+
 // MARK: - Protocols
 
-extension Department: Creatable, Readable, Updatable, Deletable { }
+extension Department: Readable, Updatable, Deletable { }

--- a/JamfKit/Sources/Models/Department.swift
+++ b/JamfKit/Sources/Models/Department.swift
@@ -14,9 +14,13 @@ public final class Department: BaseObject { }
 
 extension Department: Endpoint, Creatable {
 
+    // MARK: - Constants
+
+    public static var Endpoint: String = "departments"
+
     // MARK: - Properties
 
     public var endpoint: String {
-        return "departments"
+        return Department.Endpoint
     }
 }

--- a/JamfKit/Sources/Models/Department.swift
+++ b/JamfKit/Sources/Models/Department.swift
@@ -2,11 +2,21 @@
 //  Department.swift
 //  JamfKit
 //
-//  Copyright © 2017 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
-
-import Foundation
 
 /// Represents a physical department.
 @objc(JMFKDepartment)
 public final class Department: BaseObject { }
+
+// MARK: - Protocols
+
+extension Department: Endpoint, Creatable {
+
+    // MARK: - Properties
+
+    public var endpoint: String {
+        return "departments"
+    }
+}

--- a/JamfKit/Sources/Models/Department.swift
+++ b/JamfKit/Sources/Models/Department.swift
@@ -8,19 +8,13 @@
 
 /// Represents a physical department.
 @objc(JMFKDepartment)
-public final class Department: BaseObject { }
-
-// MARK: - Protocols
-
-extension Department: Endpoint, Creatable {
+public final class Department: BaseObject, Endpoint {
 
     // MARK: - Constants
 
-    public static var Endpoint: String = "departments"
-
-    // MARK: - Properties
-
-    public var endpoint: String {
-        return Department.Endpoint
-    }
+    public static let Endpoint: String = "departments"
 }
+
+// MARK: - Protocols
+
+extension Department: Creatable, Readable, Updatable, Deletable { }

--- a/JamfKit/Sources/Models/Department.swift
+++ b/JamfKit/Sources/Models/Department.swift
@@ -19,11 +19,71 @@ public final class Department: BaseObject, Endpoint {
 
 extension Department: Creatable {
 
-    public func create() -> URLRequest? {
-        return self.createRequest()
+    public func createRequest() -> URLRequest? {
+        return getCreateRequest()
     }
 }
 
-// MARK: - Protocols
+// MARK: - Readable
 
-extension Department: Readable, Updatable, Deletable { }
+extension Department: Readable {
+
+    public static func readAllRequest() -> URLRequest? {
+        return getReadAllRequest()
+    }
+
+    public static func readRequest(identifier: String) -> URLRequest? {
+        return getReadRequest(identifier: identifier)
+    }
+
+    public func readRequest() -> URLRequest? {
+        return getReadRequest()
+    }
+
+    /// Returns a GET **URLRequest** based on the supplied name.
+    public static func readRequest(name: String) -> URLRequest? {
+        return getReadRequest(name: name)
+    }
+
+    /// Returns a GET **URLRequest** based on the email.
+    public func readRequestWithName() -> URLRequest? {
+        return getReadRequestWithName()
+    }
+}
+
+// MARK: - Updatable
+
+extension Department: Updatable {
+
+    public func updateRequest() -> URLRequest? {
+        return getUpdateRequest()
+    }
+
+    /// Returns a PUT **URLRequest** based on the name.
+    public func updateRequestWithName() -> URLRequest? {
+        return getUpdateRequestWithName()
+    }
+}
+
+// MARK: - Deletable
+
+extension Department: Deletable {
+
+    public static func deleteRequest(identifier: String) -> URLRequest? {
+        return getDeleteRequest(identifier: identifier)
+    }
+
+    public func deleteRequest() -> URLRequest? {
+        return getDeleteRequest()
+    }
+
+    /// Returns a DELETE **URLRequest** based on the supplied name.
+    public static func deleteRequest(name: String) -> URLRequest? {
+        return getDeleteRequest(name: name)
+    }
+
+    /// Returns a DELETE **URLRequest** based on the name.
+    public func deleteRequestWithName() -> URLRequest? {
+        return getDeleteRequestWithName()
+    }
+}

--- a/JamfKit/Sources/Models/DirectoryBinding.swift
+++ b/JamfKit/Sources/Models/DirectoryBinding.swift
@@ -73,6 +73,15 @@ public final class DirectoryBinding: BaseObject, Endpoint {
     }
 }
 
+// MARK: - Creatable
+
+extension DirectoryBinding: Creatable {
+
+    public func create() -> URLRequest? {
+        return self.createRequest()
+    }
+}
+
 // MARK: - Protocols
 
-extension DirectoryBinding: Creatable, Readable, Updatable, Deletable { }
+extension DirectoryBinding: Readable, Updatable, Deletable { }

--- a/JamfKit/Sources/Models/DirectoryBinding.swift
+++ b/JamfKit/Sources/Models/DirectoryBinding.swift
@@ -23,22 +23,22 @@ public final class DirectoryBinding: BaseObject, Endpoint {
     // MARK: - Properties
 
     @objc
-    public var priority: UInt
+    public var priority: UInt = 0
 
     @objc
-    public var domain: String
+    public var domain = ""
 
     @objc
-    public var username: String
+    public var username = ""
 
     @objc
-    public var password: String
+    public var password = ""
 
     @objc
-    public var computerOrganisationalUnit: String
+    public var computerOrganisationalUnit = ""
 
     @objc
-    public var type: String
+    public var type = ""
 
     // MARK: - Initialization
 
@@ -51,6 +51,10 @@ public final class DirectoryBinding: BaseObject, Endpoint {
         type = json[DirectoryBinding.TypeKey] as? String ?? ""
 
         super.init(json: json)
+    }
+
+    public override init?(identifier: UInt, name: String) {
+        super.init(identifier: identifier, name: name)
     }
 
     // MARK: - Functions

--- a/JamfKit/Sources/Models/DirectoryBinding.swift
+++ b/JamfKit/Sources/Models/DirectoryBinding.swift
@@ -77,11 +77,71 @@ public final class DirectoryBinding: BaseObject, Endpoint {
 
 extension DirectoryBinding: Creatable {
 
-    public func create() -> URLRequest? {
-        return self.createRequest()
+    public func createRequest() -> URLRequest? {
+        return getCreateRequest()
     }
 }
 
-// MARK: - Protocols
+// MARK: - Readable
 
-extension DirectoryBinding: Readable, Updatable, Deletable { }
+extension DirectoryBinding: Readable {
+
+    public static func readAllRequest() -> URLRequest? {
+        return getReadAllRequest()
+    }
+
+    public static func readRequest(identifier: String) -> URLRequest? {
+        return getReadRequest(identifier: identifier)
+    }
+
+    public func readRequest() -> URLRequest? {
+        return getReadRequest()
+    }
+
+    /// Returns a GET **URLRequest** based on the supplied name.
+    public static func readRequest(name: String) -> URLRequest? {
+        return getReadRequest(name: name)
+    }
+
+    /// Returns a GET **URLRequest** based on the email.
+    public func readRequestWithName() -> URLRequest? {
+        return getReadRequestWithName()
+    }
+}
+
+// MARK: - Updatable
+
+extension DirectoryBinding: Updatable {
+
+    public func updateRequest() -> URLRequest? {
+        return getUpdateRequest()
+    }
+
+    /// Returns a PUT **URLRequest** based on the name.
+    public func updateRequestWithName() -> URLRequest? {
+        return getUpdateRequestWithName()
+    }
+}
+
+// MARK: - Deletable
+
+extension DirectoryBinding: Deletable {
+
+    public static func deleteRequest(identifier: String) -> URLRequest? {
+        return getDeleteRequest(identifier: identifier)
+    }
+
+    public func deleteRequest() -> URLRequest? {
+        return getDeleteRequest()
+    }
+
+    /// Returns a DELETE **URLRequest** based on the supplied name.
+    public static func deleteRequest(name: String) -> URLRequest? {
+        return getDeleteRequest(name: name)
+    }
+
+    /// Returns a DELETE **URLRequest** based on the name.
+    public func deleteRequestWithName() -> URLRequest? {
+        return getDeleteRequestWithName()
+    }
+}

--- a/JamfKit/Sources/Models/DirectoryBinding.swift
+++ b/JamfKit/Sources/Models/DirectoryBinding.swift
@@ -72,9 +72,7 @@ public final class DirectoryBinding: BaseObject {
 
 extension DirectoryBinding: Endpoint, Creatable {
 
-    // MARK: - Properties
+    // MARK: - Constants
 
-    public var endpoint: String {
-        return "directorybindings"
-    }
+    public static var Endpoint: String = "directorybindings"
 }

--- a/JamfKit/Sources/Models/DirectoryBinding.swift
+++ b/JamfKit/Sources/Models/DirectoryBinding.swift
@@ -8,10 +8,11 @@
 
 /// Represents a logical binding between a computer and an active directory user.
 @objc(JMFKDirectoryBinding)
-public final class DirectoryBinding: BaseObject {
+public final class DirectoryBinding: BaseObject, Endpoint {
 
     // MARK: - Constants
 
+    public static let Endpoint: String = "directorybindings"
     static let PriorityKey = "priority"
     static let DomainKey = "domain"
     static let UsernameKey = "username"
@@ -70,9 +71,4 @@ public final class DirectoryBinding: BaseObject {
 
 // MARK: - Protocols
 
-extension DirectoryBinding: Endpoint, Creatable {
-
-    // MARK: - Constants
-
-    public static var Endpoint: String = "directorybindings"
-}
+extension DirectoryBinding: Creatable, Readable, Updatable, Deletable { }

--- a/JamfKit/Sources/Models/DirectoryBinding.swift
+++ b/JamfKit/Sources/Models/DirectoryBinding.swift
@@ -2,10 +2,9 @@
 //  DirectoryBinding.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
-
-import Foundation
 
 /// Represents a logical binding between a computer and an active directory user.
 @objc(JMFKDirectoryBinding)
@@ -66,5 +65,16 @@ public final class DirectoryBinding: BaseObject {
         json[DirectoryBinding.TypeKey] = type
 
         return json
+    }
+}
+
+// MARK: - Protocols
+
+extension DirectoryBinding: Endpoint, Creatable {
+
+    // MARK: - Properties
+
+    public var endpoint: String {
+        return "directorybindings"
     }
 }

--- a/JamfKit/Sources/Models/HardwareGroup/HardwareGroup.swift
+++ b/JamfKit/Sources/Models/HardwareGroup/HardwareGroup.swift
@@ -8,6 +8,7 @@
 
 @objc(JMFKHardwareGroup)
 public class HardwareGroup: BaseObject {
+
     // MARK: - Constants
 
     static let IsSmartKey = "is_smart"
@@ -17,10 +18,10 @@ public class HardwareGroup: BaseObject {
     // MARK: - Properties
 
     @objc
-    public var isSmart: Bool
+    public var isSmart = false
 
     @objc
-    public var criteria: [HardwareGroupCriterion]
+    public var criteria = [HardwareGroupCriterion]()
 
     @objc
     public var site: Site?
@@ -33,6 +34,10 @@ public class HardwareGroup: BaseObject {
         site = HardwareGroup.parseSite(from: json)
 
         super.init(json: json)
+    }
+
+    internal override init?(identifier: UInt, name: String) {
+        super.init(identifier: identifier, name: name)
     }
 
     // MARK: - Functions

--- a/JamfKit/Sources/Models/HardwareGroup/HardwareGroup.swift
+++ b/JamfKit/Sources/Models/HardwareGroup/HardwareGroup.swift
@@ -36,7 +36,7 @@ public class HardwareGroup: BaseObject {
         super.init(json: json)
     }
 
-    internal override init?(identifier: UInt, name: String) {
+    override init?(identifier: UInt, name: String) {
         super.init(identifier: identifier, name: name)
     }
 

--- a/JamfKit/Sources/Models/HardwareGroup/HardwareGroup.swift
+++ b/JamfKit/Sources/Models/HardwareGroup/HardwareGroup.swift
@@ -2,10 +2,9 @@
 //  HardwareGroup.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
-
-import Foundation
 
 @objc(JMFKHardwareGroup)
 public class HardwareGroup: BaseObject {

--- a/JamfKit/Sources/Models/HardwareGroup/HardwareGroupCriterion.swift
+++ b/JamfKit/Sources/Models/HardwareGroup/HardwareGroupCriterion.swift
@@ -2,13 +2,12 @@
 //  HardwareGroupCriterion.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
-import Foundation
-
 @objc(JMFKHardwareGroupCriterion)
-public final class HardwareGroupCriterion: NSObject, Identifiable {
+public final class HardwareGroupCriterion: NSObject, Requestable {
 
     // MARK: - Constants
 

--- a/JamfKit/Sources/Models/HardwareGroup/HardwareGroupCriterion.swift
+++ b/JamfKit/Sources/Models/HardwareGroup/HardwareGroupCriterion.swift
@@ -22,25 +22,25 @@ public final class HardwareGroupCriterion: NSObject, Requestable {
     // MARK: - Properties
 
     @objc
-    public var name: String
+    public var name = ""
 
     @objc
-    public var priority: UInt
+    public var priority: UInt = 0
 
     @objc
-    public var andOr: String
+    public var andOr = ""
 
     @objc
-    public var searchType: String
+    public var searchType = ""
 
     @objc
-    public var value: UInt
+    public var value: UInt = 0
 
     @objc
-    public var openingParen: Bool
+    public var openingParen = false
 
     @objc
-    public var closingParen: Bool
+    public var closingParen = false
 
     // MARK: - Initialization
 
@@ -52,6 +52,16 @@ public final class HardwareGroupCriterion: NSObject, Requestable {
         value = json[HardwareGroupCriterion.ValueKey] as? UInt ?? 0
         openingParen = json[HardwareGroupCriterion.OpeningParenKey] as? Bool ?? false
         closingParen = json[HardwareGroupCriterion.ClosingParenKey] as? Bool ?? false
+    }
+
+    public init?(name: String) {
+        guard !name.isEmpty else {
+            return nil
+        }
+
+        self.name = name
+
+        super.init()
     }
 
     // MARK: - Functions

--- a/JamfKit/Sources/Models/MobileDevice/MobileDevice.swift
+++ b/JamfKit/Sources/Models/MobileDevice/MobileDevice.swift
@@ -8,10 +8,11 @@
 
 /// Represents a Jamf managed mobile device, contains the general information about the device.
 @objc(JMFKMobileDevice)
-public final class MobileDevice: NSObject, Requestable {
+public final class MobileDevice: NSObject, Requestable, Endpoint, Subset {
 
     // MARK: - Constants
 
+    public static let Endpoint: String = "mobiledevices"
     static let GeneralKey = "general"
 
     // MARK: - Properties
@@ -47,17 +48,74 @@ public final class MobileDevice: NSObject, Requestable {
     }
 }
 
-// MARK: - Protocols
+// MARK: - Creatable
 
-extension MobileDevice: Endpoint, Creatable {
-
-    // MARK: - Constants
-
-    public static var Endpoint: String = "mobiledevices"
-
-    // MARK: - Functions
+extension MobileDevice: Creatable {
 
     public func create() -> URLRequest? {
         return SessionManager.instance.createRequest(for: self, key: BaseObject.CodingKeys.identifier.rawValue, value: String(general.identifier))
+    }
+}
+
+// MARK: - Readable
+
+extension MobileDevice: Readable {
+
+    public func read() -> URLRequest? {
+        return MobileDevice.read(identifier: String(general.identifier))
+    }
+
+    public func readWithName() -> URLRequest? {
+        return SessionManager.instance.readRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: general.name)
+    }
+
+    public func readWithUdid() -> URLRequest? {
+        return SessionManager.instance.readRequest(for: self, key: MobileDeviceGeneral.UDIDKey, value: general.udid)
+    }
+
+    public func readWithSerialNumber() -> URLRequest? {
+        return SessionManager.instance.readRequest(for: self, key: MobileDeviceGeneral.SerialNumberKey, value: general.serialNumber)
+    }
+}
+
+// MARK: - Updatable
+
+extension MobileDevice: Updatable {
+
+    public func update() -> URLRequest? {
+        return SessionManager.instance.updateRequest(for: self, key: BaseObject.CodingKeys.identifier.rawValue, value: String(general.identifier))
+    }
+
+    public func updateWithName() -> URLRequest? {
+        return SessionManager.instance.updateRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: general.name)
+    }
+
+    public func updateWithUdid() -> URLRequest? {
+        return SessionManager.instance.updateRequest(for: self, key: MobileDeviceGeneral.UDIDKey, value: general.udid)
+    }
+
+    public func updateWithSerialNumber() -> URLRequest? {
+        return SessionManager.instance.updateRequest(for: self, key: MobileDeviceGeneral.SerialNumberKey, value: general.serialNumber)
+    }
+}
+
+// MARK: - Deletable
+
+extension MobileDevice: Deletable {
+
+    public func delete() -> URLRequest? {
+        return MobileDevice.delete(identifier: String(general.identifier))
+    }
+
+    public func deleteWithName() -> URLRequest? {
+        return SessionManager.instance.deleteRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: general.name)
+    }
+
+    public func deleteWithUdid() -> URLRequest? {
+        return SessionManager.instance.deleteRequest(for: self, key: MobileDeviceGeneral.UDIDKey, value: general.udid)
+    }
+
+    public func deleteWithSerialNumber() -> URLRequest? {
+        return SessionManager.instance.deleteRequest(for: self, key: MobileDeviceGeneral.SerialNumberKey, value: general.serialNumber)
     }
 }

--- a/JamfKit/Sources/Models/MobileDevice/MobileDevice.swift
+++ b/JamfKit/Sources/Models/MobileDevice/MobileDevice.swift
@@ -60,7 +60,7 @@ public final class MobileDevice: NSObject, Requestable, Endpoint, Subset {
 
 extension MobileDevice: Creatable {
 
-    public func create() -> URLRequest? {
+    public func createRequest() -> URLRequest? {
         return SessionManager.instance.createRequest(for: self, key: BaseObject.CodingKeys.identifier.rawValue, value: String(general.identifier))
     }
 }
@@ -69,20 +69,46 @@ extension MobileDevice: Creatable {
 
 extension MobileDevice: Readable {
 
-    public func read() -> URLRequest? {
-        return MobileDevice.read(identifier: String(general.identifier))
+    public static func readAllRequest() -> URLRequest? {
+        return getReadAllRequest()
     }
 
-    public func readWithName() -> URLRequest? {
-        return SessionManager.instance.readRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: general.name)
+    public static func readRequest(identifier: String) -> URLRequest? {
+        return getReadRequest(identifier: identifier)
     }
 
-    public func readWithUdid() -> URLRequest? {
-        return SessionManager.instance.readRequest(for: self, key: MobileDeviceGeneral.UDIDKey, value: general.udid)
+    public func readRequest() -> URLRequest? {
+        return MobileDevice.readRequest(identifier: String(general.identifier))
     }
 
-    public func readWithSerialNumber() -> URLRequest? {
-        return SessionManager.instance.readRequest(for: self, key: MobileDeviceGeneral.SerialNumberKey, value: general.serialNumber)
+    /// Returns a GET **URLRequest** based on the supplied name.
+    public static func readRequest(name: String) -> URLRequest? {
+        return SessionManager.instance.readRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: name)
+    }
+
+    /// Returns a GET **URLRequest** based on the email.
+    public func readRequestWithName() -> URLRequest? {
+        return MobileDevice.readRequest(name: general.name)
+    }
+
+    /// Returns a GET **URLRequest** based on the supplied udid.
+    public static func readRequest(udid: String) -> URLRequest? {
+        return SessionManager.instance.readRequest(for: self, key: ComputerGeneral.UDIDKey, value: udid)
+    }
+
+    /// Returns a GET **URLRequest** based on the supplied udid.
+    public func readRequestWithUdid() -> URLRequest? {
+        return MobileDevice.readRequest(udid: general.udid)
+    }
+
+    /// Returns a GET **URLRequest** based on the supplied udid.
+    public static func readRequest(serialNumber: String) -> URLRequest? {
+        return SessionManager.instance.readRequest(for: self, key: ComputerGeneral.SerialNumberKey, value: serialNumber)
+    }
+
+    /// Returns a GET **URLRequest** based on the supplied serial number.
+    public func readRequestWithSerialNumber() -> URLRequest? {
+        return MobileDevice.readRequest(serialNumber: general.serialNumber)
     }
 }
 
@@ -90,19 +116,22 @@ extension MobileDevice: Readable {
 
 extension MobileDevice: Updatable {
 
-    public func update() -> URLRequest? {
+    public func updateRequest() -> URLRequest? {
         return SessionManager.instance.updateRequest(for: self, key: BaseObject.CodingKeys.identifier.rawValue, value: String(general.identifier))
     }
 
-    public func updateWithName() -> URLRequest? {
+    /// Returns a PUT **URLRequest** based on the name.
+    public func updateRequestWithName() -> URLRequest? {
         return SessionManager.instance.updateRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: general.name)
     }
 
-    public func updateWithUdid() -> URLRequest? {
+    /// Returns a PUT **URLRequest** based on the udid.
+    public func updateRequestWithUdid() -> URLRequest? {
         return SessionManager.instance.updateRequest(for: self, key: MobileDeviceGeneral.UDIDKey, value: general.udid)
     }
 
-    public func updateWithSerialNumber() -> URLRequest? {
+    /// Returns a PUT **URLRequest** based on the serial number.
+    public func updateRequestWithSerialNumber() -> URLRequest? {
         return SessionManager.instance.updateRequest(for: self, key: MobileDeviceGeneral.SerialNumberKey, value: general.serialNumber)
     }
 }
@@ -111,19 +140,41 @@ extension MobileDevice: Updatable {
 
 extension MobileDevice: Deletable {
 
-    public func delete() -> URLRequest? {
-        return MobileDevice.delete(identifier: String(general.identifier))
+    public static func deleteRequest(identifier: String) -> URLRequest? {
+        return getDeleteRequest(identifier: identifier)
     }
 
-    public func deleteWithName() -> URLRequest? {
-        return SessionManager.instance.deleteRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: general.name)
+    public func deleteRequest() -> URLRequest? {
+        return MobileDevice.deleteRequest(identifier: String(general.identifier))
     }
 
-    public func deleteWithUdid() -> URLRequest? {
-        return SessionManager.instance.deleteRequest(for: self, key: MobileDeviceGeneral.UDIDKey, value: general.udid)
+    /// Returns a DELETE **URLRequest** based on the supplied name.
+    public static func deleteRequest(name: String) -> URLRequest? {
+        return SessionManager.instance.deleteRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: name)
     }
 
-    public func deleteWithSerialNumber() -> URLRequest? {
-        return SessionManager.instance.deleteRequest(for: self, key: MobileDeviceGeneral.SerialNumberKey, value: general.serialNumber)
+    /// Returns a DELETE **URLRequest** based on the name.
+    public func deleteRequestWithName() -> URLRequest? {
+        return MobileDevice.deleteRequest(name: general.name)
+    }
+
+    /// Returns a DELETE **URLRequest** based on the supplied udid.
+    public static func deleteRequest(udid: String) -> URLRequest? {
+        return SessionManager.instance.deleteRequest(for: self, key: ComputerGeneral.UDIDKey, value: udid)
+    }
+
+    /// Returns a DELETE **URLRequest** based on the udid.
+    public func deleteRequestWithUdid() -> URLRequest? {
+        return MobileDevice.deleteRequest(udid: general.udid)
+    }
+
+    /// Returns a DELETE **URLRequest** based on the supplied serial number.
+    public static func deleteRequest(serialNumber: String) -> URLRequest? {
+        return SessionManager.instance.deleteRequest(for: self, key: ComputerGeneral.SerialNumberKey, value: serialNumber)
+    }
+
+    /// Returns a DELETE **URLRequest** based on the serial number.
+    public func deleteRequestWithSerialNumber() -> URLRequest? {
+        return MobileDevice.deleteRequest(serialNumber: general.serialNumber)
     }
 }

--- a/JamfKit/Sources/Models/MobileDevice/MobileDevice.swift
+++ b/JamfKit/Sources/Models/MobileDevice/MobileDevice.swift
@@ -37,6 +37,14 @@ public final class MobileDevice: NSObject, Requestable, Endpoint, Subset {
         self.general = general
     }
 
+    public init?(identifier: UInt, name: String) {
+        guard let general = MobileDeviceGeneral(identifier: identifier, name: name) else {
+            return nil
+        }
+
+        self.general = general
+    }
+
     // MARK: - Functions
 
     public func toJSON() -> [String: Any] {

--- a/JamfKit/Sources/Models/MobileDevice/MobileDevice.swift
+++ b/JamfKit/Sources/Models/MobileDevice/MobileDevice.swift
@@ -2,14 +2,13 @@
 //  MobileDevice.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
-
-import Foundation
 
 /// Represents a Jamf managed mobile device, contains the general information about the device.
 @objc(JMFKMobileDevice)
-public final class MobileDevice: NSObject, Identifiable {
+public final class MobileDevice: NSObject, Requestable {
 
     // MARK: - Constants
 
@@ -45,5 +44,22 @@ public final class MobileDevice: NSObject, Identifiable {
         json[MobileDevice.GeneralKey] = general.toJSON()
 
         return json
+    }
+}
+
+// MARK: - Protocols
+
+extension MobileDevice: Endpoint, Creatable {
+
+    // MARK: - Properties
+
+    public var endpoint: String {
+        return "mobiledevices"
+    }
+
+    // MARK: - Functions
+
+    public func create(with key: String) -> URLRequest? {
+        return SessionManager.instance.createRequest(for: self, key: key, value: String(general.identifier))
     }
 }

--- a/JamfKit/Sources/Models/MobileDevice/MobileDevice.swift
+++ b/JamfKit/Sources/Models/MobileDevice/MobileDevice.swift
@@ -51,15 +51,13 @@ public final class MobileDevice: NSObject, Requestable {
 
 extension MobileDevice: Endpoint, Creatable {
 
-    // MARK: - Properties
+    // MARK: - Constants
 
-    public var endpoint: String {
-        return "mobiledevices"
-    }
+    public static var Endpoint: String = "mobiledevices"
 
     // MARK: - Functions
 
-    public func create(with key: String) -> URLRequest? {
-        return SessionManager.instance.createRequest(for: self, key: key, value: String(general.identifier))
+    public func create() -> URLRequest? {
+        return SessionManager.instance.createRequest(for: self, key: BaseObject.CodingKeys.identifier.rawValue, value: String(general.identifier))
     }
 }

--- a/JamfKit/Sources/Models/MobileDevice/MobileDeviceGeneral.swift
+++ b/JamfKit/Sources/Models/MobileDevice/MobileDeviceGeneral.swift
@@ -55,121 +55,121 @@ public final class MobileDeviceGeneral: BaseObject {
     // MARK: - Properties
 
     @objc
-    public var displayName: String
+    public var displayName = ""
 
     @objc
-    public var deviceName: String
+    public var deviceName = ""
 
     @objc
-    public var assetTag: String
+    public var assetTag = ""
 
     @objc
     public var lastInventoryUpdate: PreciseDate?
 
     @objc
-    public var capacity: UInt
+    public var capacity: UInt = 0
 
     @objc
-    public var capacityMb: UInt
+    public var capacityMb: UInt = 0
 
     @objc
-    public var available: UInt
+    public var available: UInt = 0
 
     @objc
-    public var availableMb: UInt
+    public var availableMb: UInt = 0
 
     @objc
-    public var percentageUsed: UInt
+    public var percentageUsed: UInt = 0
 
     @objc
-    public var osType: String
+    public var osType = ""
 
     @objc
-    public var osVersion: String
+    public var osVersion = ""
 
     @objc
-    public var osBuild: String
+    public var osBuild = ""
 
     @objc
-    public var serialNumber: String
+    public var serialNumber = ""
 
     @objc
-    public var udid: String
+    public var udid = ""
 
     @objc
     public var initialEntryDate: PreciseDate?
 
     @objc
-    public var phoneNumber: String
+    public var phoneNumber = ""
 
     @objc
-    public var ipAddress: String
+    public var ipAddress = ""
 
     @objc
-    public var wifiMacAddress: String
+    public var wifiMacAddress = ""
 
     @objc
-    public var bluetoothMacAddress: String
+    public var bluetoothMacAddress = ""
 
     @objc
-    public var modemFirmware: String
+    public var modemFirmware = ""
 
     @objc
-    public var model: String
+    public var model = ""
 
     @objc
-    public var modelIdentifier: String
+    public var modelIdentifier = ""
 
     @objc
-    public var modelNumber: String
+    public var modelNumber = ""
 
     @objc
-    public var modelDisplay: String
+    public var modelDisplay = ""
 
     @objc
-    public var deviceOwnershipLevel: String
+    public var deviceOwnershipLevel = ""
 
     @objc
     public var lastEnrollment: PreciseDate?
 
     @objc
-    public var isManaged: Bool
+    public var isManaged = false
 
     @objc
-    public var isSupervised: Bool
+    public var isSupervised = false
 
     @objc
-    public var exchangeActiveSyncDeviceIdentifier: String
+    public var exchangeActiveSyncDeviceIdentifier = ""
 
     @objc
-    public var shared: String
+    public var shared = ""
 
     @objc
-    public var tethered: String
+    public var tethered = ""
 
     @objc
-    public var batteryLevel: UInt
+    public var batteryLevel: UInt = 0
 
     @objc
-    public var isBluetoothCapable: Bool
+    public var isBluetoothCapable = false
 
     @objc
-    public var isDeviceLocatorServiceEnabled: Bool
+    public var isDeviceLocatorServiceEnabled = false
 
     @objc
-    public var isDoNotDisturbEnabled: Bool
+    public var isDoNotDisturbEnabled = false
 
     @objc
-    public var isCloudBackupEnabled: Bool
+    public var isCloudBackupEnabled = false
 
     @objc
     public var lastCloudBackupDate: PreciseDate?
 
     @objc
-    public var isLocationServicesEnabled: Bool
+    public var isLocationServicesEnabled = false
 
     @objc
-    public var isITunesStoreAccountActive: Bool
+    public var isITunesStoreAccountActive = false
 
     @objc
     public var lastBackupTime: PreciseDate?
@@ -219,6 +219,10 @@ public final class MobileDeviceGeneral: BaseObject {
         lastBackupTime = PreciseDate(json: json, node: MobileDeviceGeneral.LastBackupTimeKey)
 
         super.init(json: json)
+    }
+
+    public override init?(identifier: UInt, name: String) {
+        super.init(identifier: identifier, name: name)
     }
 
     // MARK: - Functions

--- a/JamfKit/Sources/Models/MobileDevice/MobileDeviceGeneral.swift
+++ b/JamfKit/Sources/Models/MobileDevice/MobileDeviceGeneral.swift
@@ -2,10 +2,9 @@
 //  MobileDeviceGeneral.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
-
-import Foundation
 
 @objc(JMFKMobileDeviceGeneral)
 public final class MobileDeviceGeneral: BaseObject {

--- a/JamfKit/Sources/Models/MobileDeviceGroup/MobileDeviceGroup.swift
+++ b/JamfKit/Sources/Models/MobileDeviceGroup/MobileDeviceGroup.swift
@@ -51,6 +51,15 @@ public final class MobileDeviceGroup: HardwareGroup, Endpoint {
     }
 }
 
+// MARK: - Creatable
+
+extension MobileDeviceGroup: Creatable {
+
+    public func create() -> URLRequest? {
+        return self.createRequest()
+    }
+}
+
 // MARK: - Protocols
 
-extension MobileDeviceGroup: Creatable, Readable, Updatable, Deletable { }
+extension MobileDeviceGroup: Readable, Updatable, Deletable { }

--- a/JamfKit/Sources/Models/MobileDeviceGroup/MobileDeviceGroup.swift
+++ b/JamfKit/Sources/Models/MobileDeviceGroup/MobileDeviceGroup.swift
@@ -8,10 +8,11 @@
 
 /// Represents a group of mobile devices managed by Jamf, contains grouping information.
 @objc(JMFKMobileDeviceGroup)
-public final class MobileDeviceGroup: HardwareGroup {
+public final class MobileDeviceGroup: HardwareGroup, Endpoint {
 
     // MARK: - Constants
 
+    public static let Endpoint: String = "mobiledevicegroups"
     static let MobileDevicesKey = "mobile_devices"
 
     // MARK: - Properties
@@ -48,9 +49,4 @@ public final class MobileDeviceGroup: HardwareGroup {
 
 // MARK: - Protocols
 
-extension MobileDeviceGroup: Endpoint, Creatable {
-
-    // MARK: - Constants
-
-    public static var Endpoint: String = "mobiledevicegroups"
-}
+extension MobileDeviceGroup: Creatable, Readable, Updatable, Deletable { }

--- a/JamfKit/Sources/Models/MobileDeviceGroup/MobileDeviceGroup.swift
+++ b/JamfKit/Sources/Models/MobileDeviceGroup/MobileDeviceGroup.swift
@@ -18,7 +18,7 @@ public final class MobileDeviceGroup: HardwareGroup, Endpoint {
     // MARK: - Properties
 
     @objc
-    public var mobileDevices: [MobileDeviceGeneral]
+    public var mobileDevices = [MobileDeviceGeneral]()
 
     // MARK: - Initialization
 
@@ -26,6 +26,10 @@ public final class MobileDeviceGroup: HardwareGroup, Endpoint {
         mobileDevices = MobileDeviceGroup.parseMobileDevices(json: json)
 
         super.init(json: json)
+    }
+
+    public override init?(identifier: UInt, name: String) {
+        super.init(identifier: identifier, name: name)
     }
 
     // MARK: - Functions

--- a/JamfKit/Sources/Models/MobileDeviceGroup/MobileDeviceGroup.swift
+++ b/JamfKit/Sources/Models/MobileDeviceGroup/MobileDeviceGroup.swift
@@ -50,9 +50,7 @@ public final class MobileDeviceGroup: HardwareGroup {
 
 extension MobileDeviceGroup: Endpoint, Creatable {
 
-    // MARK: - Properties
+    // MARK: - Constants
 
-    public var endpoint: String {
-        return "mobiledevicegroups"
-    }
+    public static var Endpoint: String = "mobiledevicegroups"
 }

--- a/JamfKit/Sources/Models/MobileDeviceGroup/MobileDeviceGroup.swift
+++ b/JamfKit/Sources/Models/MobileDeviceGroup/MobileDeviceGroup.swift
@@ -2,10 +2,9 @@
 //  MobileDeviceGroup.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
-
-import Foundation
 
 /// Represents a group of mobile devices managed by Jamf, contains grouping information.
 @objc(JMFKMobileDeviceGroup)
@@ -44,5 +43,16 @@ public final class MobileDeviceGroup: HardwareGroup {
 
     private static func parseMobileDevices(json: [String: Any]) -> [MobileDeviceGeneral] {
         return BaseObject.parseElements(from: json, nodeKey: MobileDeviceGroup.MobileDevicesKey, singleNodeKey: "mobile_device")
+    }
+}
+
+// MARK: - Protocols
+
+extension MobileDeviceGroup: Endpoint, Creatable {
+
+    // MARK: - Properties
+
+    public var endpoint: String {
+        return "mobiledevicegroups"
     }
 }

--- a/JamfKit/Sources/Models/MobileDeviceGroup/MobileDeviceGroup.swift
+++ b/JamfKit/Sources/Models/MobileDeviceGroup/MobileDeviceGroup.swift
@@ -55,11 +55,71 @@ public final class MobileDeviceGroup: HardwareGroup, Endpoint {
 
 extension MobileDeviceGroup: Creatable {
 
-    public func create() -> URLRequest? {
-        return self.createRequest()
+    public func createRequest() -> URLRequest? {
+        return getCreateRequest()
     }
 }
 
-// MARK: - Protocols
+// MARK: - Readable
 
-extension MobileDeviceGroup: Readable, Updatable, Deletable { }
+extension MobileDeviceGroup: Readable {
+
+    public static func readAllRequest() -> URLRequest? {
+        return getReadAllRequest()
+    }
+
+    public static func readRequest(identifier: String) -> URLRequest? {
+        return getReadRequest(identifier: identifier)
+    }
+
+    public func readRequest() -> URLRequest? {
+        return getReadRequest()
+    }
+
+    /// Returns a GET **URLRequest** based on the supplied name.
+    public static func readRequest(name: String) -> URLRequest? {
+        return getReadRequest(name: name)
+    }
+
+    /// Returns a GET **URLRequest** based on the email.
+    public func readRequestWithName() -> URLRequest? {
+        return getReadRequestWithName()
+    }
+}
+
+// MARK: - Updatable
+
+extension MobileDeviceGroup: Updatable {
+
+    public func updateRequest() -> URLRequest? {
+        return getUpdateRequest()
+    }
+
+    /// Returns a PUT **URLRequest** based on the name.
+    public func updateRequestWithName() -> URLRequest? {
+        return getUpdateRequestWithName()
+    }
+}
+
+// MARK: - Deletable
+
+extension MobileDeviceGroup: Deletable {
+
+    public static func deleteRequest(identifier: String) -> URLRequest? {
+        return getDeleteRequest(identifier: identifier)
+    }
+
+    public func deleteRequest() -> URLRequest? {
+        return getDeleteRequest()
+    }
+
+    /// Returns a DELETE **URLRequest** based on the supplied name.
+    public static func deleteRequest(name: String) -> URLRequest? {
+        return getDeleteRequest(name: name)
+    }
+
+    /// Returns a DELETE **URLRequest** based on the name.
+    public func deleteRequestWithName() -> URLRequest? {
+        return getDeleteRequestWithName()
+    }
+}

--- a/JamfKit/Sources/Models/NetbootServer.swift
+++ b/JamfKit/Sources/Models/NetbootServer.swift
@@ -2,10 +2,9 @@
 //  NetbootServer.swift
 //  JamfKit
 //
-//  Copyright © 2017 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
-
-import Foundation
 
 /// Represents a physical netboot server, contains information about the server and it's configuration.
 @objc(JMFKNetbootServer)
@@ -106,5 +105,16 @@ public final class NetbootServer: BaseObject {
         json[NetbootServer.BootDeviceKey] = bootDevice
 
         return json
+    }
+}
+
+// MARK: - Protocols
+
+extension NetbootServer: Endpoint, Creatable {
+
+    // MARK: - Properties
+
+    public var endpoint: String {
+        return "netbootservers"
     }
 }

--- a/JamfKit/Sources/Models/NetbootServer.swift
+++ b/JamfKit/Sources/Models/NetbootServer.swift
@@ -8,10 +8,11 @@
 
 /// Represents a physical netboot server, contains information about the server and it's configuration.
 @objc(JMFKNetbootServer)
-public final class NetbootServer: BaseObject {
+public final class NetbootServer: BaseObject, Endpoint {
 
     // MARK: - Constants
 
+    public static let Endpoint: String = "netbootservers"
     static let IpAddressKey = "ip_address"
     static let DefaultImageKey = "default_image"
     static let SpecificImageKey = "specific_image"
@@ -110,9 +111,4 @@ public final class NetbootServer: BaseObject {
 
 // MARK: - Protocols
 
-extension NetbootServer: Endpoint, Creatable {
-
-    // MARK: - Constants
-
-    public static var Endpoint: String = "netbootservers"
-}
+extension NetbootServer: Creatable, Readable, Updatable, Deletable { }

--- a/JamfKit/Sources/Models/NetbootServer.swift
+++ b/JamfKit/Sources/Models/NetbootServer.swift
@@ -112,9 +112,7 @@ public final class NetbootServer: BaseObject {
 
 extension NetbootServer: Endpoint, Creatable {
 
-    // MARK: - Properties
+    // MARK: - Constants
 
-    public var endpoint: String {
-        return "netbootservers"
-    }
+    public static var Endpoint: String = "netbootservers"
 }

--- a/JamfKit/Sources/Models/NetbootServer.swift
+++ b/JamfKit/Sources/Models/NetbootServer.swift
@@ -29,40 +29,40 @@ public final class NetbootServer: BaseObject, Endpoint {
     // MARK: - Properties
 
     @objc
-    public var ipAddress: String
+    public var ipAddress = ""
 
     @objc
-    public var isDefaultImage: Bool
+    public var isDefaultImage = false
 
     @objc
-    public var isSpecificImage: Bool
+    public var isSpecificImage = false
 
     @objc
-    public var targetPlatform: String
+    public var targetPlatform = ""
 
     @objc
-    public var sharePoint: String
+    public var sharePoint = ""
 
     @objc
-    public var set: String
+    public var set = ""
 
     @objc
-    public var image: String
+    public var image = ""
 
     @objc
-    public var filesystemProtocol: String
+    public var filesystemProtocol = ""
 
     @objc
-    public var configureManually: Bool
+    public var configureManually = false
 
     @objc
-    public var bootArguments: String
+    public var bootArguments = ""
 
     @objc
-    public var bootFile: String
+    public var bootFile = ""
 
     @objc
-    public var bootDevice: String
+    public var bootDevice = ""
 
     public override var description: String {
         return "[\(String(describing: NetbootServer.self))][\(identifier) - \(self.ipAddress)]"
@@ -85,6 +85,10 @@ public final class NetbootServer: BaseObject, Endpoint {
         bootDevice = json[NetbootServer.BootDeviceKey] as? String ?? ""
 
         super.init(json: json)
+    }
+
+    public override init?(identifier: UInt, name: String) {
+        super.init(identifier: identifier, name: name)
     }
 
     // MARK: - Functions

--- a/JamfKit/Sources/Models/NetbootServer.swift
+++ b/JamfKit/Sources/Models/NetbootServer.swift
@@ -113,6 +113,15 @@ public final class NetbootServer: BaseObject, Endpoint {
     }
 }
 
+// MARK: - Creatable
+
+extension NetbootServer: Creatable {
+
+    public func create() -> URLRequest? {
+        return self.createRequest()
+    }
+}
+
 // MARK: - Protocols
 
-extension NetbootServer: Creatable, Readable, Updatable, Deletable { }
+extension NetbootServer: Readable, Updatable, Deletable { }

--- a/JamfKit/Sources/Models/NetbootServer.swift
+++ b/JamfKit/Sources/Models/NetbootServer.swift
@@ -117,11 +117,71 @@ public final class NetbootServer: BaseObject, Endpoint {
 
 extension NetbootServer: Creatable {
 
-    public func create() -> URLRequest? {
-        return self.createRequest()
+    public func createRequest() -> URLRequest? {
+        return getCreateRequest()
     }
 }
 
-// MARK: - Protocols
+// MARK: - Readable
 
-extension NetbootServer: Readable, Updatable, Deletable { }
+extension NetbootServer: Readable {
+
+    public static func readAllRequest() -> URLRequest? {
+        return getReadAllRequest()
+    }
+
+    public static func readRequest(identifier: String) -> URLRequest? {
+        return getReadRequest(identifier: identifier)
+    }
+
+    public func readRequest() -> URLRequest? {
+        return getReadRequest()
+    }
+
+    /// Returns a GET **URLRequest** based on the supplied name.
+    public static func readRequest(name: String) -> URLRequest? {
+        return getReadRequest(name: name)
+    }
+
+    /// Returns a GET **URLRequest** based on the email.
+    public func readRequestWithName() -> URLRequest? {
+        return getReadRequestWithName()
+    }
+}
+
+// MARK: - Updatable
+
+extension NetbootServer: Updatable {
+
+    public func updateRequest() -> URLRequest? {
+        return getUpdateRequest()
+    }
+
+    /// Returns a PUT **URLRequest** based on the name.
+    public func updateRequestWithName() -> URLRequest? {
+        return getUpdateRequestWithName()
+    }
+}
+
+// MARK: - Deletable
+
+extension NetbootServer: Deletable {
+
+    public static func deleteRequest(identifier: String) -> URLRequest? {
+        return getDeleteRequest(identifier: identifier)
+    }
+
+    public func deleteRequest() -> URLRequest? {
+        return getDeleteRequest()
+    }
+
+    /// Returns a DELETE **URLRequest** based on the supplied name.
+    public static func deleteRequest(name: String) -> URLRequest? {
+        return getDeleteRequest(name: name)
+    }
+
+    /// Returns a DELETE **URLRequest** based on the name.
+    public func deleteRequestWithName() -> URLRequest? {
+        return getDeleteRequestWithName()
+    }
+}

--- a/JamfKit/Sources/Models/NetworkSegment.swift
+++ b/JamfKit/Sources/Models/NetworkSegment.swift
@@ -2,10 +2,9 @@
 //  NetworkSegment.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
-
-import Foundation
 
 /// Represents a physical network segment, contains information about the segment and it's configuration.
 @objc(JMFKNetworkSegment)

--- a/JamfKit/Sources/Models/NetworkSegment.swift
+++ b/JamfKit/Sources/Models/NetworkSegment.swift
@@ -27,37 +27,37 @@ public final class NetworkSegment: BaseObject {
     // MARK: - Properties
 
     @objc
-    public var startingAddress: String
+    public var startingAddress = ""
 
     @objc
-    public var endingAddress: String
+    public var endingAddress = ""
 
     @objc
-    public var distributionServer: String
+    public var distributionServer = ""
 
     @objc
-    public var distributionPoint: String
+    public var distributionPoint = ""
 
     @objc
-    public var url: String
+    public var url = ""
 
     @objc
-    public var netbootServer: String
+    public var netbootServer = ""
 
     @objc
-    public var swuServer: String
+    public var swuServer = ""
 
     @objc
-    public var building: String
+    public var building = ""
 
     @objc
-    public var department: String
+    public var department = ""
 
     @objc
-    public var overridesBuildings: Bool
+    public var overridesBuildings = false
 
     @objc
-    public var overridesDepartments: Bool
+    public var overridesDepartments = false
 
     // MARK: - Initialization
 
@@ -75,6 +75,10 @@ public final class NetworkSegment: BaseObject {
         overridesDepartments = json[NetworkSegment.OverrideDepartmentsKey] as? Bool ?? false
 
         super.init(json: json)
+    }
+
+    public override init?(identifier: UInt, name: String) {
+        super.init(identifier: identifier, name: name)
     }
 
     // MARK: - Functions

--- a/JamfKit/Sources/Models/Package.swift
+++ b/JamfKit/Sources/Models/Package.swift
@@ -33,55 +33,55 @@ public final class Package: BaseObject {
     // MARK: - Properties
 
     @objc
-    public var category: String
+    public var category = ""
 
     @objc
-    public var filename: String
+    public var filename = ""
 
     @objc
-    public var information: String
+    public var information = ""
 
     @objc
-    public var notes: String
+    public var notes = ""
 
     @objc
-    public var priority: UInt
+    public var priority: UInt = 0
 
     @objc
-    public var isRebootRequired: Bool
+    public var isRebootRequired = false
 
     @objc
-    public var shouldFillUserTemplate: Bool
+    public var shouldFillUserTemplate = false
 
     @objc
-    public var shouldFillExistingUsers: Bool
+    public var shouldFillExistingUsers = false
 
     @objc
-    public var isBootVolumeRequired: Bool
+    public var isBootVolumeRequired = false
 
     @objc
-    public var allowsUninstallation: Bool
+    public var allowsUninstallation = false
 
     @objc
-    public var osRequirements: String
+    public var osRequirements = ""
 
     @objc
-    public var requiredProcessor: String
+    public var requiredProcessor = ""
 
     @objc
-    public var switchWithPackage: String
+    public var switchWithPackage = ""
 
     @objc
-    public var shouldInstallIfReportedAvailable: Bool
+    public var shouldInstallIfReportedAvailable = false
 
     @objc
-    public var reinstallOption: String
+    public var reinstallOption = ""
 
     @objc
-    public var triggeringFiles: String
+    public var triggeringFiles = ""
 
     @objc
-    public var shouldSendNotificaton: Bool
+    public var shouldSendNotificaton = false
 
     // MARK: - Initialization
 
@@ -105,6 +105,10 @@ public final class Package: BaseObject {
         shouldSendNotificaton = json[Package.SendNotificationKey] as? Bool ?? false
 
         super.init(json: json)
+    }
+
+    public override init?(identifier: UInt, name: String) {
+        super.init(identifier: identifier, name: name)
     }
 
     // MARK: - Functions

--- a/JamfKit/Sources/Models/Package.swift
+++ b/JamfKit/Sources/Models/Package.swift
@@ -2,10 +2,9 @@
 //  Package.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
-
-import Foundation
 
 /// Represents a logical application package, contains information about the application requirements and capabilities.
 @objc(JMFKPackage)

--- a/JamfKit/Sources/Models/Partition.swift
+++ b/JamfKit/Sources/Models/Partition.swift
@@ -24,28 +24,33 @@ public final class Partition: NSObject, Requestable {
     // MARK: - Properties
 
     @objc
-    public var name: String
+    public var name = ""
 
     @objc
-    public var sizeInGigabytes: UInt
+    public var sizeInGigabytes: UInt = 0
 
     @objc
-    public var maximumPercentage: UInt
+    public var maximumPercentage: UInt = 0
 
     @objc
-    public var format: String
+    public var format = ""
 
     @objc
-    public var isRestorePartition: Bool
+    public var isRestorePartition = false
 
     @objc
-    public var computerConfiguration: String
+    public var computerConfiguration = ""
 
     @objc
-    public var reimage: Bool
+    public var reimage = false
 
     @objc
-    public var appendToName: String
+    public var appendToName = ""
+
+    @objc
+    public override var description: String {
+        return "[\(String(describing: type(of: self)))][\(name)]"
+    }
 
     // MARK: - Initialization
 
@@ -58,6 +63,16 @@ public final class Partition: NSObject, Requestable {
         computerConfiguration = json[Partition.ComputerConfigurationKey] as? String ?? ""
         reimage = json[Partition.ReimageKey] as? Bool ?? false
         appendToName = json[Partition.AppendToNameKey] as? String ?? ""
+    }
+
+    public init?(name: String) {
+        guard !name.isEmpty else {
+            return nil
+        }
+
+        self.name = name
+
+        super.init()
     }
 
     // MARK: - Functions

--- a/JamfKit/Sources/Models/Partition.swift
+++ b/JamfKit/Sources/Models/Partition.swift
@@ -2,14 +2,13 @@
 //  Partition.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
-
-import Foundation
 
 /// Represents a logical partition for an hard drive installed inside an hardware element managed by Jamf.
 @objc(JMFKPartition)
-public final class Partition: NSObject, Identifiable {
+public final class Partition: NSObject, Requestable {
 
     // MARK: - Constants
 

--- a/JamfKit/Sources/Models/Policy/Policy.swift
+++ b/JamfKit/Sources/Models/Policy/Policy.swift
@@ -2,14 +2,13 @@
 //  Policy.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
-
-import Foundation
 
 /// Reprents as logical policy that can be applied to any hardware element managed by Jamf.
 @objc(JMFKPolicy)
-public final class Policy: NSObject, Identifiable {
+public final class Policy: NSObject, Requestable {
 
     // MARK: - Constants
 

--- a/JamfKit/Sources/Models/Policy/Policy.swift
+++ b/JamfKit/Sources/Models/Policy/Policy.swift
@@ -37,6 +37,16 @@ public final class Policy: NSObject, Requestable, Endpoint, Subset {
         self.general = general
     }
 
+    public init?(identifier: UInt, name: String) {
+        guard let general = PolicyGeneral(identifier: identifier, name: name) else {
+            return nil
+        }
+
+        self.general = general
+
+        super.init()
+    }
+
     // MARK: - Functions
 
     public func toJSON() -> [String: Any] {

--- a/JamfKit/Sources/Models/Policy/Policy.swift
+++ b/JamfKit/Sources/Models/Policy/Policy.swift
@@ -62,7 +62,7 @@ public final class Policy: NSObject, Requestable, Endpoint, Subset {
 
 extension Policy: Creatable {
 
-    public func create() -> URLRequest? {
+    public func createRequest() -> URLRequest? {
         return SessionManager.instance.createRequest(for: self, key: BaseObject.CodingKeys.identifier.rawValue, value: String(general.identifier))
     }
 }
@@ -71,11 +71,19 @@ extension Policy: Creatable {
 
 extension Policy: Readable {
 
-    public func read() -> URLRequest? {
-        return Policy.read(identifier: String(general.identifier))
+    public static func readAllRequest() -> URLRequest? {
+        return getReadAllRequest()
     }
 
-    public func readWithName() -> URLRequest? {
+    public static func readRequest(identifier: String) -> URLRequest? {
+        return getReadRequest(identifier: identifier)
+    }
+
+    public func readRequest() -> URLRequest? {
+        return Policy.readRequest(identifier: String(general.identifier))
+    }
+
+    public func readRequestWithName() -> URLRequest? {
         return SessionManager.instance.readRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: general.name)
     }
 }
@@ -84,11 +92,12 @@ extension Policy: Readable {
 
 extension Policy: Updatable {
 
-    public func update() -> URLRequest? {
+    public func updateRequest() -> URLRequest? {
         return SessionManager.instance.updateRequest(for: self, key: BaseObject.CodingKeys.identifier.rawValue, value: String(general.identifier))
     }
 
-    public func updateWithName() -> URLRequest? {
+    /// Returns a PUT **URLRequest** based on the name.
+    public func updateRequestWithName() -> URLRequest? {
         return SessionManager.instance.updateRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: general.name)
     }
 }
@@ -97,11 +106,21 @@ extension Policy: Updatable {
 
 extension Policy: Deletable {
 
-    public func delete() -> URLRequest? {
-        return Policy.delete(identifier: String(general.identifier))
+    public static func deleteRequest(identifier: String) -> URLRequest? {
+        return getDeleteRequest(identifier: identifier)
     }
 
-    public func deleteWithName() -> URLRequest? {
-        return SessionManager.instance.deleteRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: general.name)
+    public func deleteRequest() -> URLRequest? {
+        return Policy.deleteRequest(identifier: String(general.identifier))
+    }
+
+    /// Returns a DELETE **URLRequest** based on the supplied name.
+    public static func deleteRequest(name: String) -> URLRequest? {
+        return getDeleteRequest(name: name)
+    }
+
+    /// Returns a DELETE **URLRequest** based on the name.
+    public func deleteRequestWithName() -> URLRequest? {
+        return Policy.deleteRequest(name: general.name)
     }
 }

--- a/JamfKit/Sources/Models/Policy/Policy.swift
+++ b/JamfKit/Sources/Models/Policy/Policy.swift
@@ -8,10 +8,11 @@
 
 /// Reprents as logical policy that can be applied to any hardware element managed by Jamf.
 @objc(JMFKPolicy)
-public final class Policy: NSObject, Requestable {
+public final class Policy: NSObject, Requestable, Endpoint, Subset {
 
     // MARK: - Constants
 
+    public static let Endpoint: String = "policies"
     static let GeneralKey = "general"
 
     // MARK: - Properties
@@ -44,5 +45,53 @@ public final class Policy: NSObject, Requestable {
         json[Policy.GeneralKey] = general.toJSON()
 
         return json
+    }
+}
+
+// MARK: - Creatable
+
+extension Policy: Creatable {
+
+    public func create() -> URLRequest? {
+        return SessionManager.instance.createRequest(for: self, key: BaseObject.CodingKeys.identifier.rawValue, value: String(general.identifier))
+    }
+}
+
+// MARK: - Readable
+
+extension Policy: Readable {
+
+    public func read() -> URLRequest? {
+        return Policy.read(identifier: String(general.identifier))
+    }
+
+    public func readWithName() -> URLRequest? {
+        return SessionManager.instance.readRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: general.name)
+    }
+}
+
+// MARK: - Updatable
+
+extension Policy: Updatable {
+
+    public func update() -> URLRequest? {
+        return SessionManager.instance.updateRequest(for: self, key: BaseObject.CodingKeys.identifier.rawValue, value: String(general.identifier))
+    }
+
+    public func updateWithName() -> URLRequest? {
+        return SessionManager.instance.updateRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: general.name)
+    }
+}
+
+// MARK: - Deletable
+
+extension Policy: Deletable {
+
+    public func delete() -> URLRequest? {
+        return Policy.delete(identifier: String(general.identifier))
+    }
+
+    public func deleteWithName() -> URLRequest? {
+        return SessionManager.instance.deleteRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: general.name)
     }
 }

--- a/JamfKit/Sources/Models/Policy/PolicyCategory.swift
+++ b/JamfKit/Sources/Models/Policy/PolicyCategory.swift
@@ -2,10 +2,9 @@
 //  PolicyCategory.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
-
-import Foundation
 
 @objc(JMFKPolicyCategory)
 public final class PolicyCategory: BaseObject {

--- a/JamfKit/Sources/Models/Policy/PolicyCategory.swift
+++ b/JamfKit/Sources/Models/Policy/PolicyCategory.swift
@@ -16,7 +16,7 @@ public final class PolicyCategory: BaseObject {
     // MARK: - Properties
 
     @objc
-    public var priority: UInt
+    public var priority: UInt = 0
 
     // MARK: - Initialization
 
@@ -28,6 +28,10 @@ public final class PolicyCategory: BaseObject {
         self.priority = priority
 
         super.init(json: json)
+    }
+
+    public override init?(identifier: UInt, name: String) {
+        super.init(identifier: identifier, name: name)
     }
 
     // MARK: - Functions

--- a/JamfKit/Sources/Models/Policy/PolicyDateTimeLimitations.swift
+++ b/JamfKit/Sources/Models/Policy/PolicyDateTimeLimitations.swift
@@ -26,13 +26,13 @@ public final class PolicyDateTimeLimitations: NSObject, Requestable {
     public var expirationDate: PreciseDate?
 
     @objc
-    public var noExecutionOn: [String: String]
+    public var noExecutionOn = [String: String]()
 
     @objc
-    public var noExecutionStart: String
+    public var noExecutionStart = ""
 
     @objc
-    public var noExecutionEnd: String
+    public var noExecutionEnd = ""
 
     // MARK: - Initialization
 
@@ -42,6 +42,10 @@ public final class PolicyDateTimeLimitations: NSObject, Requestable {
         noExecutionOn = json[PolicyDateTimeLimitations.NoExecuteOnKey] as? [String: String] ?? [String: String]()
         noExecutionStart = json[PolicyDateTimeLimitations.NoExecuteStartKey] as? String ?? ""
         noExecutionEnd = json[PolicyDateTimeLimitations.NoExecuteEndKey] as? String ?? ""
+    }
+
+    public override init() {
+        super.init()
     }
 
     // MARK: - Functions

--- a/JamfKit/Sources/Models/Policy/PolicyDateTimeLimitations.swift
+++ b/JamfKit/Sources/Models/Policy/PolicyDateTimeLimitations.swift
@@ -2,13 +2,12 @@
 //  PolicyDateTimeLimitations.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
-import Foundation
-
 @objc(JMFKPolicyDateTimeLimitations)
-public final class PolicyDateTimeLimitations: NSObject, Identifiable {
+public final class PolicyDateTimeLimitations: NSObject, Requestable {
 
     // MARK: - Constants
 

--- a/JamfKit/Sources/Models/Policy/PolicyGeneral.swift
+++ b/JamfKit/Sources/Models/Policy/PolicyGeneral.swift
@@ -2,10 +2,9 @@
 //  PolicyGeneral.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
-
-import Foundation
 
 @objc(JMFKPolicyGeneral)
 public final class PolicyGeneral: BaseObject {

--- a/JamfKit/Sources/Models/Policy/PolicyGeneral.swift
+++ b/JamfKit/Sources/Models/Policy/PolicyGeneral.swift
@@ -34,43 +34,43 @@ public final class PolicyGeneral: BaseObject {
     // MARK: - Properties
 
     @objc
-    public var isEnabled: Bool
+    public var isEnabled = false
 
     @objc
-    public var trigger: String
+    public var trigger = ""
 
     @objc
-    public var triggerCheckin: Bool
+    public var triggerCheckin = false
 
     @objc
-    public var triggerEnrollmentComplete: Bool
+    public var triggerEnrollmentComplete = false
 
     @objc
-    public var triggerLogin: Bool
+    public var triggerLogin = false
 
     @objc
-    public var triggerLogout: Bool
+    public var triggerLogout = false
 
     @objc
-    public var triggerNetworkStateChanged: Bool
+    public var triggerNetworkStateChanged = false
 
     @objc
-    public var triggerStartup: Bool
+    public var triggerStartup = false
 
     @objc
-    public var triggerOther: String
+    public var triggerOther = ""
 
     @objc
-    public var frequency: String
+    public var frequency = ""
 
     @objc
-    public var locationUserOnly: Bool
+    public var locationUserOnly = false
 
     @objc
-    public var targetDrive: String
+    public var targetDrive = ""
 
     @objc
-    public var offline: Bool
+    public var offline = false
 
     @objc
     public var category: PolicyCategory?
@@ -85,7 +85,7 @@ public final class PolicyGeneral: BaseObject {
     public var overrideDefaultSettings: PolicyOverrideDefaultSettings?
 
     @objc
-    public var networkRequirements: String
+    public var networkRequirements = ""
 
     @objc
     public var site: Site?
@@ -130,6 +130,14 @@ public final class PolicyGeneral: BaseObject {
         }
 
         super.init(json: json)
+    }
+
+    public override init?(identifier: UInt, name: String) {
+        dateTimeLimitations = PolicyDateTimeLimitations()
+        networkLimitations = PolicyNetworkLimitations()
+        overrideDefaultSettings = PolicyOverrideDefaultSettings()
+
+        super.init(identifier: identifier, name: name)
     }
 
     // MARK: - Functions

--- a/JamfKit/Sources/Models/Policy/PolicyNetworkLimitations.swift
+++ b/JamfKit/Sources/Models/Policy/PolicyNetworkLimitations.swift
@@ -17,16 +17,20 @@ public final class PolicyNetworkLimitations: NSObject, Requestable {
     // MARK: - Properties
 
     @objc
-    public var minimumNetworkConnection: String
+    public var minimumNetworkConnection = ""
 
     @objc
-    public var anyIpAddress: Bool
+    public var anyIpAddress = false
 
     // MARK: - Initialization
 
     public init?(json: [String: Any], node: String = "") {
         minimumNetworkConnection = json[PolicyNetworkLimitations.MinimumNetworkConnectionKey] as? String ?? ""
         anyIpAddress = json[PolicyNetworkLimitations.AnyIpAddressKey] as? Bool ?? false
+    }
+
+    public override init() {
+        super.init()
     }
 
     // MARK: - Functions

--- a/JamfKit/Sources/Models/Policy/PolicyNetworkLimitations.swift
+++ b/JamfKit/Sources/Models/Policy/PolicyNetworkLimitations.swift
@@ -2,13 +2,12 @@
 //  PolicyNetworkLimitations.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
-import Foundation
-
 @objc(JMFKPolicyNetworkLimitations)
-public final class PolicyNetworkLimitations: NSObject, Identifiable {
+public final class PolicyNetworkLimitations: NSObject, Requestable {
 
     // MARK: - Constants
 

--- a/JamfKit/Sources/Models/Policy/PolicyOverrideDefaultSettings.swift
+++ b/JamfKit/Sources/Models/Policy/PolicyOverrideDefaultSettings.swift
@@ -20,19 +20,19 @@ public final class PolicyOverrideDefaultSettings: NSObject, Requestable {
     // MARK: - Properties
 
     @objc
-    public var targetDrive: String
+    public var targetDrive = ""
 
     @objc
-    public var distributionPoint: String
+    public var distributionPoint = ""
 
     @objc
-    public var shouldForceAfpSmb: Bool
+    public var shouldForceAfpSmb = false
 
     @objc
-    public var sus: String
+    public var sus = ""
 
     @objc
-    public var netbootServer: String
+    public var netbootServer = ""
 
     // MARK: - Initialization
 
@@ -42,6 +42,10 @@ public final class PolicyOverrideDefaultSettings: NSObject, Requestable {
         shouldForceAfpSmb = json[PolicyOverrideDefaultSettings.ForceAfpSmbKey] as? Bool ?? false
         sus = json[PolicyOverrideDefaultSettings.SusKey] as? String ?? ""
         netbootServer = json[PolicyOverrideDefaultSettings.NetbootServerKey] as? String ?? ""
+    }
+
+    public override init() {
+        super.init()
     }
 
     // MARK: - Functions

--- a/JamfKit/Sources/Models/Policy/PolicyOverrideDefaultSettings.swift
+++ b/JamfKit/Sources/Models/Policy/PolicyOverrideDefaultSettings.swift
@@ -2,13 +2,12 @@
 //  PolicyOverrideDefaultSettings.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
-import Foundation
-
 @objc(JMFKPolicyOverrideDefaultSettings)
-public final class PolicyOverrideDefaultSettings: NSObject, Identifiable {
+public final class PolicyOverrideDefaultSettings: NSObject, Requestable {
 
     // MARK: - Constants
 

--- a/JamfKit/Sources/Models/PreciseDate.swift
+++ b/JamfKit/Sources/Models/PreciseDate.swift
@@ -2,14 +2,13 @@
 //  Epoch.swift
 //  JamfKit
 //
-//  Copyright © 2017 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
-
-import Foundation
 
 /// Represents a logical date within JSS api, contains 3 properties, the date itself, an epoch version of the date and an UTC version of the date.
 @objc(JMFKPreciseDate)
-public final class PreciseDate: NSObject, Identifiable {
+public final class PreciseDate: NSObject, Requestable {
 
     // MARK: - Constants
 

--- a/JamfKit/Sources/Models/Printer.swift
+++ b/JamfKit/Sources/Models/Printer.swift
@@ -8,10 +8,11 @@
 
 /// Represents a physical printer, contains information about the printer and it's configuration.
 @objc(JMFKPrinter)
-public final class Printer: BaseObject {
+public final class Printer: BaseObject, Endpoint {
 
     // MARK: - Constants
 
+    public static let Endpoint: String = "printers"
     static let CategoryKey = "category"
     static let UriKey = "uri"
     static let CupsNameKey = "CUPS_name"
@@ -116,9 +117,4 @@ public final class Printer: BaseObject {
 
 // MARK: - Protocols
 
-extension Printer: Endpoint, Creatable {
-
-    // MARK: - Constants
-
-    public static var Endpoint: String = "printers"
-}
+extension Printer: Creatable, Readable, Updatable, Deletable { }

--- a/JamfKit/Sources/Models/Printer.swift
+++ b/JamfKit/Sources/Models/Printer.swift
@@ -29,40 +29,40 @@ public final class Printer: BaseObject, Endpoint {
     // MARK: - Properties
 
     @objc
-    public var category: String
+    public var category = ""
 
     @objc
-    public var uri: String
+    public var uri = ""
 
     @objc
-    public var cupsName: String
+    public var cupsName = ""
 
     @objc
-    public var location: String
+    public var location = ""
 
     @objc
-    public var model: String
+    public var model = ""
 
     @objc
-    public var information: String
+    public var information = ""
 
     @objc
-    public var notes: String
+    public var notes = ""
 
     @objc
-    public var makeDefault: Bool
+    public var makeDefault = false
 
     @objc
-    public var useGeneric: Bool
+    public var useGeneric = false
 
     @objc
-    public var ppd: String
+    public var ppd = ""
 
     @objc
-    public var ppdPath: String
+    public var ppdPath = ""
 
     @objc
-    public var ppdContents: String
+    public var ppdContents = ""
 
     public override var description: String {
         let baseDescription = super.description
@@ -91,6 +91,10 @@ public final class Printer: BaseObject, Endpoint {
         ppdContents = json[Printer.PpdContentsKey] as? String ?? ""
 
         super.init(json: json)
+    }
+
+    public override init?(identifier: UInt, name: String) {
+        super.init(identifier: identifier, name: name)
     }
 
     // MARK: - Functions

--- a/JamfKit/Sources/Models/Printer.swift
+++ b/JamfKit/Sources/Models/Printer.swift
@@ -119,6 +119,15 @@ public final class Printer: BaseObject, Endpoint {
     }
 }
 
+// MARK: - Creatable
+
+extension Printer: Creatable {
+
+    public func create() -> URLRequest? {
+        return self.createRequest()
+    }
+}
+
 // MARK: - Protocols
 
-extension Printer: Creatable, Readable, Updatable, Deletable { }
+extension Printer: Readable, Updatable, Deletable { }

--- a/JamfKit/Sources/Models/Printer.swift
+++ b/JamfKit/Sources/Models/Printer.swift
@@ -123,11 +123,71 @@ public final class Printer: BaseObject, Endpoint {
 
 extension Printer: Creatable {
 
-    public func create() -> URLRequest? {
-        return self.createRequest()
+    public func createRequest() -> URLRequest? {
+        return getCreateRequest()
     }
 }
 
-// MARK: - Protocols
+// MARK: - Readable
 
-extension Printer: Readable, Updatable, Deletable { }
+extension Printer: Readable {
+
+    public static func readAllRequest() -> URLRequest? {
+        return getReadAllRequest()
+    }
+
+    public static func readRequest(identifier: String) -> URLRequest? {
+        return getReadRequest(identifier: identifier)
+    }
+
+    public func readRequest() -> URLRequest? {
+        return getReadRequest()
+    }
+
+    /// Returns a GET **URLRequest** based on the supplied name.
+    public static func readRequest(name: String) -> URLRequest? {
+        return getReadRequest(name: name)
+    }
+
+    /// Returns a GET **URLRequest** based on the email.
+    public func readRequestWithName() -> URLRequest? {
+        return getReadRequestWithName()
+    }
+}
+
+// MARK: - Updatable
+
+extension Printer: Updatable {
+
+    public func updateRequest() -> URLRequest? {
+        return getUpdateRequest()
+    }
+
+    /// Returns a PUT **URLRequest** based on the name.
+    public func updateRequestWithName() -> URLRequest? {
+        return getUpdateRequestWithName()
+    }
+}
+
+// MARK: - Deletable
+
+extension Printer: Deletable {
+
+    public static func deleteRequest(identifier: String) -> URLRequest? {
+        return getDeleteRequest(identifier: identifier)
+    }
+
+    public func deleteRequest() -> URLRequest? {
+        return getDeleteRequest()
+    }
+
+    /// Returns a DELETE **URLRequest** based on the supplied name.
+    public static func deleteRequest(name: String) -> URLRequest? {
+        return getDeleteRequest(name: name)
+    }
+
+    /// Returns a DELETE **URLRequest** based on the name.
+    public func deleteRequestWithName() -> URLRequest? {
+        return getDeleteRequestWithName()
+    }
+}

--- a/JamfKit/Sources/Models/Printer.swift
+++ b/JamfKit/Sources/Models/Printer.swift
@@ -2,10 +2,9 @@
 //  Printer.swift
 //  JamfKit
 //
-//  Copyright © 2017 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
-
-import Foundation
 
 /// Represents a physical printer, contains information about the printer and it's configuration.
 @objc(JMFKPrinter)
@@ -112,5 +111,16 @@ public final class Printer: BaseObject {
         json[Printer.PpdContentsKey] = ppdContents
 
         return json
+    }
+}
+
+// MARK: - Protocols
+
+extension Printer: Endpoint, Creatable {
+
+    // MARK: - Properties
+
+    public var endpoint: String {
+        return "printers"
     }
 }

--- a/JamfKit/Sources/Models/Printer.swift
+++ b/JamfKit/Sources/Models/Printer.swift
@@ -118,9 +118,7 @@ public final class Printer: BaseObject {
 
 extension Printer: Endpoint, Creatable {
 
-    // MARK: - Properties
+    // MARK: - Constants
 
-    public var endpoint: String {
-        return "printers"
-    }
+    public static var Endpoint: String = "printers"
 }

--- a/JamfKit/Sources/Models/SMTPServer.swift
+++ b/JamfKit/Sources/Models/SMTPServer.swift
@@ -8,10 +8,11 @@
 
 /// Represents a physical SMTP server, contains information about the server and it's configuration.
 @objc(JMFKSMTPServer)
-public final class SMTPServer: NSObject, Requestable {
+public final class SMTPServer: NSObject, Requestable, Endpoint {
 
     // MARK: - Constants
 
+    public static let Endpoint: String = "smtpserver"
     static let EnabledKey = "enabled"
     static let HostKey = "host"
     static let PortKey = "port"
@@ -103,5 +104,30 @@ public final class SMTPServer: NSObject, Requestable {
         json[SMTPServer.SendFromEmailKey] = sendFromEmail
 
         return json
+    }
+}
+
+// MARK: - Readable
+
+extension SMTPServer: Readable {
+    public static func readAll() -> URLRequest? {
+        return nil
+    }
+
+    public static func read(identifier: String) -> URLRequest? {
+        return nil
+    }
+
+    public func read() -> URLRequest? {
+        return SessionManager.instance.readRequest(for: self)
+    }
+}
+
+// MARK: - Updatable
+
+extension SMTPServer: Updatable {
+
+    public func update() -> URLRequest? {
+        return SessionManager.instance.updateRequest(for: self)
     }
 }

--- a/JamfKit/Sources/Models/SMTPServer.swift
+++ b/JamfKit/Sources/Models/SMTPServer.swift
@@ -121,15 +121,15 @@ public final class SMTPServer: NSObject, Requestable, Endpoint {
 // MARK: - Readable
 
 extension SMTPServer: Readable {
-    public static func readAll() -> URLRequest? {
+    public static func readAllRequest() -> URLRequest? {
         return nil
     }
 
-    public static func read(identifier: String) -> URLRequest? {
+    public static func readRequest(identifier: String) -> URLRequest? {
         return nil
     }
 
-    public func read() -> URLRequest? {
+    public func readRequest() -> URLRequest? {
         return SessionManager.instance.readRequest(for: self)
     }
 }
@@ -138,7 +138,7 @@ extension SMTPServer: Readable {
 
 extension SMTPServer: Updatable {
 
-    public func update() -> URLRequest? {
+    public func updateRequest() -> URLRequest? {
         return SessionManager.instance.updateRequest(for: self)
     }
 }

--- a/JamfKit/Sources/Models/SMTPServer.swift
+++ b/JamfKit/Sources/Models/SMTPServer.swift
@@ -28,37 +28,37 @@ public final class SMTPServer: NSObject, Requestable, Endpoint {
     // MARK: - Properties
 
     @objc
-    public var isEnabled: Bool
+    public var isEnabled = false
 
     @objc
-    public var host: String
+    public var host = ""
 
     @objc
-    public var port: UInt
+    public var port: UInt = 0
 
     @objc
-    public var timeout: UInt
+    public var timeout: UInt = 0
 
     @objc
-    public var isAuthorizationRequired: Bool
+    public var isAuthorizationRequired = false
 
     @objc
-    public var username: String
+    public var username = ""
 
     @objc
-    public var password: String
+    public var password = ""
 
     @objc
-    public var isSSLEnabled: Bool
+    public var isSSLEnabled = false
 
     @objc
-    public var isTLSEnabled: Bool
+    public var isTLSEnabled = false
 
     @objc
-    public var sendFromName: String
+    public var sendFromName = ""
 
     @objc
-    public var sendFromEmail: String
+    public var sendFromEmail = ""
 
     public override var description: String {
         let baseDescription = "[\(String(describing: type(of: self)))]"
@@ -84,6 +84,17 @@ public final class SMTPServer: NSObject, Requestable, Endpoint {
         isTLSEnabled = json[SMTPServer.TlsKey] as? Bool ?? false
         sendFromName = json[SMTPServer.SendFromNameKey] as? String ?? ""
         sendFromEmail = json[SMTPServer.SendFromEmailKey] as? String ?? ""
+    }
+
+    public init?(host: String, port: UInt) {
+        guard !host.isEmpty, port > 0 else {
+            return nil
+        }
+
+        self.host = host
+        self.port = port
+
+        super.init()
     }
 
     // MARK: - Functions

--- a/JamfKit/Sources/Models/SMTPServer.swift
+++ b/JamfKit/Sources/Models/SMTPServer.swift
@@ -2,14 +2,13 @@
 //  SMTPServer.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
-
-import Foundation
 
 /// Represents a physical SMTP server, contains information about the server and it's configuration.
 @objc(JMFKSMTPServer)
-public final class SMTPServer: NSObject, Identifiable {
+public final class SMTPServer: NSObject, Requestable {
 
     // MARK: - Constants
 

--- a/JamfKit/Sources/Models/Script.swift
+++ b/JamfKit/Sources/Models/Script.swift
@@ -8,10 +8,11 @@
 
 /// Represents a logical script that can be executed on one (or more) hardware element managed by Jamf.
 @objc(JMFKScript)
-public final class Script: BaseObject {
+public final class Script: BaseObject, Endpoint {
 
     // MARK: - Constants
 
+    public static let Endpoint: String = "scripts"
     static let CategoryKey = "category"
     static let FilenameKey = "filename"
     static let InfoKey = "info"
@@ -96,9 +97,4 @@ public final class Script: BaseObject {
 
 // MARK: - Protocols
 
-extension Script: Endpoint, Creatable {
-
-    // MARK: - Constants
-
-    public static var Endpoint: String = "scripts"
-}
+extension Script: Creatable, Readable, Updatable, Deletable { }

--- a/JamfKit/Sources/Models/Script.swift
+++ b/JamfKit/Sources/Models/Script.swift
@@ -103,11 +103,71 @@ public final class Script: BaseObject, Endpoint {
 
 extension Script: Creatable {
 
-    public func create() -> URLRequest? {
-        return self.createRequest()
+    public func createRequest() -> URLRequest? {
+        return getCreateRequest()
     }
 }
 
-// MARK: - Protocols
+// MARK: - Readable
 
-extension Script: Readable, Updatable, Deletable { }
+extension Script: Readable {
+
+    public static func readAllRequest() -> URLRequest? {
+        return getReadAllRequest()
+    }
+
+    public static func readRequest(identifier: String) -> URLRequest? {
+        return getReadRequest(identifier: identifier)
+    }
+
+    public func readRequest() -> URLRequest? {
+        return getReadRequest()
+    }
+
+    /// Returns a GET **URLRequest** based on the supplied name.
+    public static func readRequest(name: String) -> URLRequest? {
+        return getReadRequest(name: name)
+    }
+
+    /// Returns a GET **URLRequest** based on the email.
+    public func readRequestWithName() -> URLRequest? {
+        return getReadRequestWithName()
+    }
+}
+
+// MARK: - Updatable
+
+extension Script: Updatable {
+
+    public func updateRequest() -> URLRequest? {
+        return getUpdateRequest()
+    }
+
+    /// Returns a PUT **URLRequest** based on the name.
+    public func updateRequestWithName() -> URLRequest? {
+        return getUpdateRequestWithName()
+    }
+}
+
+// MARK: - Deletable
+
+extension Script: Deletable {
+
+    public static func deleteRequest(identifier: String) -> URLRequest? {
+        return getDeleteRequest(identifier: identifier)
+    }
+
+    public func deleteRequest() -> URLRequest? {
+        return getDeleteRequest()
+    }
+
+    /// Returns a DELETE **URLRequest** based on the supplied name.
+    public static func deleteRequest(name: String) -> URLRequest? {
+        return getDeleteRequest(name: name)
+    }
+
+    /// Returns a DELETE **URLRequest** based on the name.
+    public func deleteRequestWithName() -> URLRequest? {
+        return getDeleteRequestWithName()
+    }
+}

--- a/JamfKit/Sources/Models/Script.swift
+++ b/JamfKit/Sources/Models/Script.swift
@@ -2,10 +2,9 @@
 //  Script.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
-
-import Foundation
 
 /// Represents a logical script that can be executed on one (or more) hardware element managed by Jamf.
 @objc(JMFKScript)
@@ -92,5 +91,16 @@ public final class Script: BaseObject {
         }
 
         return rawParameters
+    }
+}
+
+// MARK: - Protocols
+
+extension Script: Endpoint, Creatable {
+
+    // MARK: - Properties
+
+    public var endpoint: String {
+        return "scripts"
     }
 }

--- a/JamfKit/Sources/Models/Script.swift
+++ b/JamfKit/Sources/Models/Script.swift
@@ -98,9 +98,7 @@ public final class Script: BaseObject {
 
 extension Script: Endpoint, Creatable {
 
-    // MARK: - Properties
+    // MARK: - Constants
 
-    public var endpoint: String {
-        return "scripts"
-    }
+    public static var Endpoint: String = "scripts"
 }

--- a/JamfKit/Sources/Models/Script.swift
+++ b/JamfKit/Sources/Models/Script.swift
@@ -99,6 +99,15 @@ public final class Script: BaseObject, Endpoint {
     }
 }
 
+// MARK: - Creatable
+
+extension Script: Creatable {
+
+    public func create() -> URLRequest? {
+        return self.createRequest()
+    }
+}
+
 // MARK: - Protocols
 
-extension Script: Creatable, Readable, Updatable, Deletable { }
+extension Script: Readable, Updatable, Deletable { }

--- a/JamfKit/Sources/Models/Script.swift
+++ b/JamfKit/Sources/Models/Script.swift
@@ -26,31 +26,31 @@ public final class Script: BaseObject, Endpoint {
     // MARK: - Properties
 
     @objc
-    public var category: String
+    public var category = ""
 
     @objc
-    public var filename: String
+    public var filename = ""
 
     @objc
-    public var information: String
+    public var information = ""
 
     @objc
-    public var notes: String
+    public var notes = ""
 
     @objc
-    public var priority: String
+    public var priority = ""
 
     @objc
-    public var parameters: [String: String]
+    public var parameters = [String: String]()
 
     @objc
-    public var osRequirements: String
+    public var osRequirements = ""
 
     @objc
-    public var scriptContents: String
+    public var scriptContents = ""
 
     @objc
-    public var scriptEncodedContents: String
+    public var scriptEncodedContents = ""
 
     // MARK: - Initialization
 
@@ -66,6 +66,10 @@ public final class Script: BaseObject, Endpoint {
         scriptEncodedContents = json[Script.ScriptContentsEncodedKey] as? String ?? ""
 
         super.init(json: json)
+    }
+
+    public override init?(identifier: UInt, name: String) {
+        super.init(identifier: identifier, name: name)
     }
 
     // MARK: - Functions

--- a/JamfKit/Sources/Models/Site.swift
+++ b/JamfKit/Sources/Models/Site.swift
@@ -2,11 +2,21 @@
 //  Site.swift
 //  JamfKit
 //
-//  Copyright © 2017 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
-
-import Foundation
 
 /// Represents a physical location (building, office, etc.).
 @objc(JMFKSite)
 public final class Site: BaseObject { }
+
+// MARK: - Protocols
+
+extension Site: Endpoint, Creatable {
+
+    // MARK: - Properties
+
+    public var endpoint: String {
+        return "sites"
+    }
+}

--- a/JamfKit/Sources/Models/Site.swift
+++ b/JamfKit/Sources/Models/Site.swift
@@ -8,13 +8,13 @@
 
 /// Represents a physical location (building, office, etc.).
 @objc(JMFKSite)
-public final class Site: BaseObject { }
-
-// MARK: - Protocols
-
-extension Site: Endpoint, Creatable {
+public final class Site: BaseObject, Endpoint {
 
     // MARK: - Constants
 
-    public static var Endpoint: String = "sites"
+    public static let Endpoint: String = "sites"
 }
+
+// MARK: - Protocols
+
+extension Site: Creatable, Readable, Updatable, Deletable { }

--- a/JamfKit/Sources/Models/Site.swift
+++ b/JamfKit/Sources/Models/Site.swift
@@ -15,6 +15,15 @@ public final class Site: BaseObject, Endpoint {
     public static let Endpoint: String = "sites"
 }
 
+// MARK: - Creatable
+
+extension Site: Creatable {
+
+    public func create() -> URLRequest? {
+        return self.createRequest()
+    }
+}
+
 // MARK: - Protocols
 
-extension Site: Creatable, Readable, Updatable, Deletable { }
+extension Site: Readable, Updatable, Deletable { }

--- a/JamfKit/Sources/Models/Site.swift
+++ b/JamfKit/Sources/Models/Site.swift
@@ -19,11 +19,71 @@ public final class Site: BaseObject, Endpoint {
 
 extension Site: Creatable {
 
-    public func create() -> URLRequest? {
-        return self.createRequest()
+    public func createRequest() -> URLRequest? {
+        return getCreateRequest()
     }
 }
 
-// MARK: - Protocols
+// MARK: - Readable
 
-extension Site: Readable, Updatable, Deletable { }
+extension Site: Readable {
+
+    public static func readAllRequest() -> URLRequest? {
+        return getReadAllRequest()
+    }
+
+    public static func readRequest(identifier: String) -> URLRequest? {
+        return getReadRequest(identifier: identifier)
+    }
+
+    public func readRequest() -> URLRequest? {
+        return getReadRequest()
+    }
+
+    /// Returns a GET **URLRequest** based on the supplied name.
+    public static func readRequest(name: String) -> URLRequest? {
+        return getReadRequest(name: name)
+    }
+
+    /// Returns a GET **URLRequest** based on the email.
+    public func readRequestWithName() -> URLRequest? {
+        return getReadRequestWithName()
+    }
+}
+
+// MARK: - Updatable
+
+extension Site: Updatable {
+
+    public func updateRequest() -> URLRequest? {
+        return getUpdateRequest()
+    }
+
+    /// Returns a PUT **URLRequest** based on the name.
+    public func updateRequestWithName() -> URLRequest? {
+        return getUpdateRequestWithName()
+    }
+}
+
+// MARK: - Deletable
+
+extension Site: Deletable {
+
+    public static func deleteRequest(identifier: String) -> URLRequest? {
+        return getDeleteRequest(identifier: identifier)
+    }
+
+    public func deleteRequest() -> URLRequest? {
+        return getDeleteRequest()
+    }
+
+    /// Returns a DELETE **URLRequest** based on the supplied name.
+    public static func deleteRequest(name: String) -> URLRequest? {
+        return getDeleteRequest(name: name)
+    }
+
+    /// Returns a DELETE **URLRequest** based on the name.
+    public func deleteRequestWithName() -> URLRequest? {
+        return getDeleteRequestWithName()
+    }
+}

--- a/JamfKit/Sources/Models/Site.swift
+++ b/JamfKit/Sources/Models/Site.swift
@@ -14,9 +14,7 @@ public final class Site: BaseObject { }
 
 extension Site: Endpoint, Creatable {
 
-    // MARK: - Properties
+    // MARK: - Constants
 
-    public var endpoint: String {
-        return "sites"
-    }
+    public static var Endpoint: String = "sites"
 }

--- a/JamfKit/Sources/Models/User.swift
+++ b/JamfKit/Sources/Models/User.swift
@@ -112,17 +112,45 @@ public final class User: BaseObject, Endpoint {
 
 extension User: Creatable {
 
-    public func create() -> URLRequest? {
-        return self.createRequest()
+    public func createRequest() -> URLRequest? {
+        return getCreateRequest()
     }
 }
 
-// MARK: - Protocols
+// MARK: - Readable
 
 extension User: Readable {
 
-    public func readWithEmail() -> URLRequest? {
+    public static func readAllRequest() -> URLRequest? {
+        return getReadAllRequest()
+    }
+
+    public static func readRequest(identifier: String) -> URLRequest? {
+        return getReadRequest(identifier: identifier)
+    }
+
+    public func readRequest() -> URLRequest? {
+        return getReadRequest()
+    }
+
+    /// Returns a GET **URLRequest** based on the supplied name.
+    public static func readRequest(name: String) -> URLRequest? {
+        return getReadRequest(name: name)
+    }
+
+    /// Returns a GET **URLRequest** based on the email.
+    public func readRequestWithName() -> URLRequest? {
+        return getReadRequestWithName()
+    }
+
+    /// Returns a GET **URLRequest** based on the supplied email.
+    public static func readRequest(email: String) -> URLRequest? {
         return SessionManager.instance.readRequest(for: self, key: User.EmailKey, value: email)
+    }
+
+    /// Returns a GET **URLRequest** based on the email.
+    public func readRequestWithEmail() -> URLRequest? {
+        return User.readRequest(email: email)
     }
 }
 
@@ -130,7 +158,17 @@ extension User: Readable {
 
 extension User: Updatable {
 
-    public func updateWithEmail() -> URLRequest? {
+    public func updateRequest() -> URLRequest? {
+        return getUpdateRequest()
+    }
+
+    /// Returns a PUT **URLRequest** based on the name.
+    public func updateRequestWithName() -> URLRequest? {
+        return getUpdateRequestWithName()
+    }
+
+    /// Returns a PUT **URLRequest** based on the email.
+    public func updateRequestWithEmail() -> URLRequest? {
         return SessionManager.instance.updateRequest(for: self, key: User.EmailKey, value: email)
     }
 }
@@ -139,7 +177,31 @@ extension User: Updatable {
 
 extension User: Deletable {
 
-    public func deleteWithEmail() -> URLRequest? {
+    public static func deleteRequest(identifier: String) -> URLRequest? {
+        return getDeleteRequest(identifier: identifier)
+    }
+
+    public func deleteRequest() -> URLRequest? {
+        return getDeleteRequest()
+    }
+
+    /// Returns a DELETE **URLRequest** based on the supplied name.
+    public static func deleteRequest(name: String) -> URLRequest? {
+        return SessionManager.instance.deleteRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: name)
+    }
+
+    /// Returns a DELETE **URLRequest** based on the name.
+    public func deleteRequestWithName() -> URLRequest? {
+        return User.deleteRequest(name: name)
+    }
+
+    /// Returns a DELETE **URLRequest** based on the supplied email.
+    public static func deleteRequest(email: String) -> URLRequest? {
         return SessionManager.instance.deleteRequest(for: self, key: User.EmailKey, value: email)
+    }
+
+    /// Returns a DELETE **URLRequest** based on the email.
+    public func deleteRequestWithEmail() -> URLRequest? {
+        return User.deleteRequest(email: email)
     }
 }

--- a/JamfKit/Sources/Models/User.swift
+++ b/JamfKit/Sources/Models/User.swift
@@ -8,10 +8,11 @@
 
 /// Represents a Jamf user and contains the identification properties that are required to contact the actual user and identify the hardware devices assigned to him / her.
 @objc(JMFKUser)
-public final class User: BaseObject {
+public final class User: BaseObject, Endpoint {
 
     // MARK: - Constants
 
+    public static let Endpoint: String = "users"
     static let FullNameKey = "full_name"
     static let EmailKey = "email"
     static let EmailAddressKey = "email_address"
@@ -97,11 +98,33 @@ public final class User: BaseObject {
     }
 }
 
+// MARK: - Creatable
+
+extension User: Creatable { }
+
 // MARK: - Protocols
 
-extension User: Endpoint, Creatable {
+extension User: Readable {
 
-    // MARK: - Constants
+    public func readWithEmail() -> URLRequest? {
+        return SessionManager.instance.readRequest(for: self, key: User.EmailKey, value: email)
+    }
+}
 
-    public static var Endpoint: String = "users"
+// MARK: - Updatable
+
+extension User: Updatable {
+
+    public func updateWithEmail() -> URLRequest? {
+        return SessionManager.instance.updateRequest(for: self, key: User.EmailKey, value: email)
+    }
+}
+
+// MARK: - Deletable
+
+extension User: Deletable {
+
+    public func deleteWithEmail() -> URLRequest? {
+        return SessionManager.instance.deleteRequest(for: self, key: User.EmailKey, value: email)
+    }
 }

--- a/JamfKit/Sources/Models/User.swift
+++ b/JamfKit/Sources/Models/User.swift
@@ -25,31 +25,37 @@ public final class User: BaseObject, Endpoint {
     // MARK: - Properties
 
     @objc
-    public var fullName: String
+    public var fullName = ""
 
     @objc
-    public var email: String
+    public var email = ""
 
     @objc
-    public var emailAddress: String
+    public var emailAddress = ""
 
     @objc
-    public var phoneNumber: String
+    public var phoneNumber = ""
 
     @objc
-    public var position: String
+    public var position = ""
 
     @objc
-    public var enableCustomPhotoURL: Bool
+    public var enableCustomPhotoURL = false
 
     @objc
-    public var customPhotoURL: String
+    public var customPhotoURL = ""
 
     @objc
-    public var sites: [Site]
+    public var sites = [Site]()
 
     public override var description: String {
-        return "[\(String(describing: type(of: self)))][\(identifier) - \(self.fullName)]"
+        let baseDescription = super.description
+
+        if !fullName.isEmpty {
+            return "\(baseDescription)[\(self.fullName)]"
+        }
+
+        return baseDescription
     }
 
     // MARK: - Initialization
@@ -75,6 +81,10 @@ public final class User: BaseObject, Endpoint {
         self.sites = sites
 
         super.init(json: json)
+    }
+
+    public override init?(identifier: UInt, name: String) {
+        super.init(identifier: identifier, name: name)
     }
 
     public override func toJSON() -> [String: Any] {

--- a/JamfKit/Sources/Models/User.swift
+++ b/JamfKit/Sources/Models/User.swift
@@ -101,9 +101,7 @@ public final class User: BaseObject {
 
 extension User: Endpoint, Creatable {
 
-    // MARK: - Properties
+    // MARK: - Constants
 
-    public var endpoint: String {
-        return "users"
-    }
+    public static var Endpoint: String = "users"
 }

--- a/JamfKit/Sources/Models/User.swift
+++ b/JamfKit/Sources/Models/User.swift
@@ -2,10 +2,9 @@
 //  User.swift
 //  JamfKit
 //
-//  Copyright © 2017 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
-
-import Foundation
 
 /// Represents a Jamf user and contains the identification properties that are required to contact the actual user and identify the hardware devices assigned to him / her.
 @objc(JMFKUser)
@@ -95,5 +94,16 @@ public final class User: BaseObject {
         }
 
         return json
+    }
+}
+
+// MARK: - Protocols
+
+extension User: Endpoint, Creatable {
+
+    // MARK: - Properties
+
+    public var endpoint: String {
+        return "users"
     }
 }

--- a/JamfKit/Sources/Models/User.swift
+++ b/JamfKit/Sources/Models/User.swift
@@ -110,7 +110,12 @@ public final class User: BaseObject, Endpoint {
 
 // MARK: - Creatable
 
-extension User: Creatable { }
+extension User: Creatable {
+
+    public func create() -> URLRequest? {
+        return self.createRequest()
+    }
+}
 
 // MARK: - Protocols
 

--- a/JamfKit/Sources/Protocols/Endpoint.swift
+++ b/JamfKit/Sources/Protocols/Endpoint.swift
@@ -1,0 +1,17 @@
+//
+//  Endpoint.swift
+//  JamfKit
+//
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+//
+
+/// Represents any JSS object that is matched by a JSS endpoint
+@objc(JMFKEndpoint)
+public protocol Endpoint {
+
+    // MARK: - Properties
+
+    @objc
+    var endpoint: String { get }
+}

--- a/JamfKit/Sources/Protocols/Endpoint.swift
+++ b/JamfKit/Sources/Protocols/Endpoint.swift
@@ -6,7 +6,7 @@
 //  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
-/// Represents any JSS object that is matched by a JSS endpoint
+/// Represents any JSS object that is matched by a JSS endpoint.
 public protocol Endpoint {
 
     // MARK: - Properties

--- a/JamfKit/Sources/Protocols/Endpoint.swift
+++ b/JamfKit/Sources/Protocols/Endpoint.swift
@@ -7,11 +7,20 @@
 //
 
 /// Represents any JSS object that is matched by a JSS endpoint
-@objc(JMFKEndpoint)
 public protocol Endpoint {
 
     // MARK: - Properties
 
-    @objc
+    static var Endpoint: String { get }
+
     var endpoint: String { get }
+}
+
+extension Endpoint {
+
+    // MARK: - Properties
+
+    public var endpoint: String {
+        return Self.Endpoint
+    }
 }

--- a/JamfKit/Sources/Protocols/Identifiable.swift
+++ b/JamfKit/Sources/Protocols/Identifiable.swift
@@ -6,7 +6,7 @@
 //  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
-/// Represents any JSS object that can be identified (either by ID or by name)
+/// Represents any JSS object that can be identified (either by ID or by name).
 @objc(JMFKIdentifiable)
 public protocol Identifiable {
 

--- a/JamfKit/Sources/Protocols/Identifiable.swift
+++ b/JamfKit/Sources/Protocols/Identifiable.swift
@@ -16,5 +16,5 @@ public protocol Identifiable {
     var identifier: UInt { get }
 
     @objc
-    optional var name: String { get }
+    var name: String { get }
 }

--- a/JamfKit/Sources/Protocols/Identifiable.swift
+++ b/JamfKit/Sources/Protocols/Identifiable.swift
@@ -2,21 +2,19 @@
 //  Identifiable.swift
 //  JamfKit
 //
-//  Copyright © 2017 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
-import Foundation
-
+/// Represents any JSS object that can be identified (either by ID or by name)
 @objc(JMFKIdentifiable)
 public protocol Identifiable {
 
-    // MARK: - Initialization
+    // MARK: - Properties
 
     @objc
-    init?(json: [String: Any], node: String)
-
-    // MARK: - Functions
+    var identifier: UInt { get }
 
     @objc
-    func toJSON() -> [String: Any]
+    optional var name: String { get }
 }

--- a/JamfKit/Sources/Protocols/Requestable.swift
+++ b/JamfKit/Sources/Protocols/Requestable.swift
@@ -1,0 +1,27 @@
+//
+//  Requestable.swift
+//  JamfKit
+//
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+//
+
+/// Represents an object that can be used to perform requests with any JSS endpoint.
+@objc(JMFKRequestable)
+public protocol Requestable {
+
+    // MARK: - Initialization
+
+    /**
+     * Returns a JSS object instantiated from the supplied JSON payload.
+     *
+     * - Parameter json: The creation key to use for generating the URLRequest
+     * - Parameter node: Some JSS object can be nested inside a specific node, this parameter can be used to enforce it
+     */
+    init?(json: [String: Any], node: String)
+
+    // MARK: - Functions
+
+    /// Returns a JSS object as a JSON payload.
+    func toJSON() -> [String: Any]
+}

--- a/JamfKit/Sources/Protocols/Requests/Creatable.swift
+++ b/JamfKit/Sources/Protocols/Requests/Creatable.swift
@@ -13,16 +13,14 @@ public protocol Creatable {
     // MARK: - Functions
 
     /// Returns a POST **URLRequest** based on the identifier property of the supplied JSS object.
-    func create() -> URLRequest?
+    func createRequest() -> URLRequest?
 }
 
 // MARK: - Implementation
 
-public extension Creatable where Self: Endpoint & Identifiable & Requestable {
+extension Creatable where Self: Endpoint & Identifiable & Requestable {
 
-    // MARK: - Functions
-
-    func createRequest() -> URLRequest? {
+    func getCreateRequest() -> URLRequest? {
         return SessionManager.instance.createRequest(for: self, key: BaseObject.CodingKeys.identifier.rawValue, value: String(identifier))
     }
 }

--- a/JamfKit/Sources/Protocols/Requests/Creatable.swift
+++ b/JamfKit/Sources/Protocols/Requests/Creatable.swift
@@ -11,21 +11,17 @@ public protocol Creatable {
 
     // MARK: - Functions
 
-    /**
-     * Returns a CREATE **URLRequest** for the supplied JSS object.
-     *
-     * - Parameter key: The creation key to use for generating the URLRequest
-     */
-    func create(with key: String) -> URLRequest?
+    /// Returns a POST **URLRequest** based on the identifier property of the supplied JSS object.
+    func create() -> URLRequest?
 }
 
-// MARK: - Protocols
+// MARK: - Implementation
 
-public extension Creatable where Self: Endpoint & Identifiable {
+public extension Creatable where Self: Endpoint & Identifiable & Requestable {
 
     // MARK: - Functions
 
-    func create(with key: String = "id") -> URLRequest? {
-        return SessionManager.instance.createRequest(for: self, key: key, value: String(self.identifier))
+    func create() -> URLRequest? {
+        return SessionManager.instance.createRequest(for: self, key: BaseObject.CodingKeys.identifier.rawValue, value: String(identifier))
     }
 }

--- a/JamfKit/Sources/Protocols/Requests/Creatable.swift
+++ b/JamfKit/Sources/Protocols/Requests/Creatable.swift
@@ -1,0 +1,31 @@
+//
+//  Creatable.swift
+//  JamfKit
+//
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+//
+
+/// Represents an object that can be created with an URLRequest
+public protocol Creatable {
+
+    // MARK: - Functions
+
+    /**
+     * Returns a CREATE **URLRequest** for the supplied JSS object.
+     *
+     * - Parameter key: The creation key to use for generating the URLRequest
+     */
+    func create(with key: String) -> URLRequest?
+}
+
+// MARK: - Protocols
+
+public extension Creatable where Self: Endpoint & Identifiable {
+
+    // MARK: - Functions
+
+    func create(with key: String = "id") -> URLRequest? {
+        return SessionManager.instance.createRequest(for: self, key: key, value: String(self.identifier))
+    }
+}

--- a/JamfKit/Sources/Protocols/Requests/Creatable.swift
+++ b/JamfKit/Sources/Protocols/Requests/Creatable.swift
@@ -7,6 +7,7 @@
 //
 
 /// Represents an object that can be created with an URLRequest
+@objc(JMFKCreatable)
 public protocol Creatable {
 
     // MARK: - Functions
@@ -21,7 +22,7 @@ public extension Creatable where Self: Endpoint & Identifiable & Requestable {
 
     // MARK: - Functions
 
-    func create() -> URLRequest? {
+    func createRequest() -> URLRequest? {
         return SessionManager.instance.createRequest(for: self, key: BaseObject.CodingKeys.identifier.rawValue, value: String(identifier))
     }
 }

--- a/JamfKit/Sources/Protocols/Requests/Deletable.swift
+++ b/JamfKit/Sources/Protocols/Requests/Deletable.swift
@@ -37,3 +37,12 @@ public extension Deletable where Self: Endpoint & Identifiable {
         return SessionManager.instance.deleteRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: name)
     }
 }
+
+public extension Deletable where Self: Endpoint & Requestable & Subset {
+
+    // MARK: - Functions
+
+    static func delete(identifier: String) -> URLRequest? {
+        return SessionManager.instance.deleteRequest(for: self, key: BaseObject.CodingKeys.identifier.rawValue, value: identifier)
+    }
+}

--- a/JamfKit/Sources/Protocols/Requests/Deletable.swift
+++ b/JamfKit/Sources/Protocols/Requests/Deletable.swift
@@ -7,10 +7,33 @@
 //
 
 /// Represents an object that can be deleted with an URLRequest
-@objc(JMFKDeletable)
 public protocol Deletable {
 
     // MARK: - Functions
 
+    /// Returns a DELETE **URLRequest** based on the JSS object type & the supplied identifier.
+    static func delete(identifier: String) -> URLRequest?
+
+    /// Returns a DELETE **URLRequest** based on the identifier property of the supplied JSS object.
     func delete() -> URLRequest?
+}
+
+// MARK: - Implementation
+
+public extension Deletable where Self: Endpoint & Identifiable {
+
+    // MARK: - Functions
+
+    static func delete(identifier: String) -> URLRequest? {
+        return SessionManager.instance.deleteRequest(for: self, key: BaseObject.CodingKeys.identifier.rawValue, value: identifier)
+    }
+
+    func delete() -> URLRequest? {
+        return SessionManager.instance.deleteRequest(for: self, key: BaseObject.CodingKeys.identifier.rawValue, value: String(identifier))
+    }
+
+    /// Returns a DELETE **URLRequest** based on the name property of the supplied JSS object.
+    func deleteWithName() -> URLRequest? {
+        return SessionManager.instance.deleteRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: name)
+    }
 }

--- a/JamfKit/Sources/Protocols/Requests/Deletable.swift
+++ b/JamfKit/Sources/Protocols/Requests/Deletable.swift
@@ -1,0 +1,16 @@
+//
+//  Deletable.swift
+//  JamfKit
+//
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+//
+
+/// Represents an object that can be deleted with an URLRequest
+@objc(JMFKDeletable)
+public protocol Deletable {
+
+    // MARK: - Functions
+
+    func delete() -> URLRequest?
+}

--- a/JamfKit/Sources/Protocols/Requests/Deletable.swift
+++ b/JamfKit/Sources/Protocols/Requests/Deletable.swift
@@ -7,42 +7,46 @@
 //
 
 /// Represents an object that can be deleted with an URLRequest
+@objc(JMFKDeletable)
 public protocol Deletable {
 
     // MARK: - Functions
 
     /// Returns a DELETE **URLRequest** based on the JSS object type & the supplied identifier.
-    static func delete(identifier: String) -> URLRequest?
+    static func deleteRequest(identifier: String) -> URLRequest?
 
     /// Returns a DELETE **URLRequest** based on the identifier property of the supplied JSS object.
-    func delete() -> URLRequest?
+    func deleteRequest() -> URLRequest?
 }
 
 // MARK: - Implementation
 
-public extension Deletable where Self: Endpoint & Identifiable {
+extension Deletable where Self: Endpoint & Identifiable {
 
-    // MARK: - Functions
-
-    static func delete(identifier: String) -> URLRequest? {
+    static func getDeleteRequest(identifier: String) -> URLRequest? {
         return SessionManager.instance.deleteRequest(for: self, key: BaseObject.CodingKeys.identifier.rawValue, value: identifier)
     }
 
-    func delete() -> URLRequest? {
+    func getDeleteRequest() -> URLRequest? {
         return SessionManager.instance.deleteRequest(for: self, key: BaseObject.CodingKeys.identifier.rawValue, value: String(identifier))
     }
 
-    /// Returns a DELETE **URLRequest** based on the name property of the supplied JSS object.
-    func deleteWithName() -> URLRequest? {
+    static func getDeleteRequest(name: String) -> URLRequest? {
+        return SessionManager.instance.deleteRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: name)
+    }
+
+    func getDeleteRequestWithName() -> URLRequest? {
         return SessionManager.instance.deleteRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: name)
     }
 }
 
-public extension Deletable where Self: Endpoint & Requestable & Subset {
+extension Deletable where Self: Endpoint & Requestable & Subset {
 
-    // MARK: - Functions
-
-    static func delete(identifier: String) -> URLRequest? {
+    static func getDeleteRequest(identifier: String) -> URLRequest? {
         return SessionManager.instance.deleteRequest(for: self, key: BaseObject.CodingKeys.identifier.rawValue, value: identifier)
+    }
+
+    static func getDeleteRequest(name: String) -> URLRequest? {
+        return SessionManager.instance.deleteRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: name)
     }
 }

--- a/JamfKit/Sources/Protocols/Requests/Readable.swift
+++ b/JamfKit/Sources/Protocols/Requests/Readable.swift
@@ -44,3 +44,16 @@ public extension Readable where Self: Endpoint & Identifiable & Requestable {
         return SessionManager.instance.readRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: name)
     }
 }
+
+public extension Readable where Self: Endpoint & Requestable & Subset {
+
+    // MARK: - Functions
+
+    public static func readAll() -> URLRequest? {
+        return SessionManager.instance.readAllRequest(for: self.Endpoint)
+    }
+
+    static func read(identifier: String) -> URLRequest? {
+        return SessionManager.instance.readRequest(for: self, key: BaseObject.CodingKeys.identifier.rawValue, value: identifier)
+    }
+}

--- a/JamfKit/Sources/Protocols/Requests/Readable.swift
+++ b/JamfKit/Sources/Protocols/Requests/Readable.swift
@@ -7,53 +7,55 @@
 //
 
 /// Represents an object that can be read with an URLRequest
+@objc(JMFKReadable)
 public protocol Readable {
 
     // MARK: - Functions
 
     /// Returns a GET **URLRequest** based on the JSS object type.
-    static func readAll() -> URLRequest?
+    static func readAllRequest() -> URLRequest?
 
     /// Returns a GET **URLRequest** based on the JSS object type & the supplied identifier.
-    static func read(identifier: String) -> URLRequest?
+    static func readRequest(identifier: String) -> URLRequest?
 
     /// Returns a GET **URLRequest** based on the identifier property of the supplied JSS object.
-    func read() -> URLRequest?
+    func readRequest() -> URLRequest?
 }
 
 // MARK: - Implementation
 
-public extension Readable where Self: Endpoint & Identifiable & Requestable {
+extension Readable where Self: Endpoint & Identifiable & Requestable {
 
     // MARK: - Functions
 
-    static func readAll() -> URLRequest? {
+    static func getReadAllRequest() -> URLRequest? {
         return SessionManager.instance.readAllRequest(for: self.Endpoint)
     }
 
-    static func read(identifier: String) -> URLRequest? {
+    static func getReadRequest(identifier: String) -> URLRequest? {
         return SessionManager.instance.readRequest(for: self, key: BaseObject.CodingKeys.identifier.rawValue, value: identifier)
     }
 
-    func read() -> URLRequest? {
+    func getReadRequest() -> URLRequest? {
         return SessionManager.instance.readRequest(for: self, key: BaseObject.CodingKeys.identifier.rawValue, value: String(identifier))
     }
 
-    /// Returns a GET **URLRequest** based on the name property of the supplied JSS object.
-    func readWithName() -> URLRequest? {
+    static func getReadRequest(name: String) -> URLRequest? {
+        return SessionManager.instance.readRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: name)
+    }
+
+    func getReadRequestWithName() -> URLRequest? {
         return SessionManager.instance.readRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: name)
     }
 }
 
-public extension Readable where Self: Endpoint & Requestable & Subset {
+extension Readable where Self: Endpoint & Requestable & Subset {
 
-    // MARK: - Functions
-
-    public static func readAll() -> URLRequest? {
+    public static func getReadAllRequest() -> URLRequest? {
         return SessionManager.instance.readAllRequest(for: self.Endpoint)
     }
 
-    static func read(identifier: String) -> URLRequest? {
+    static func getReadRequest(identifier: String) -> URLRequest? {
         return SessionManager.instance.readRequest(for: self, key: BaseObject.CodingKeys.identifier.rawValue, value: identifier)
     }
 }

--- a/JamfKit/Sources/Protocols/Requests/Readable.swift
+++ b/JamfKit/Sources/Protocols/Requests/Readable.swift
@@ -1,0 +1,16 @@
+//
+//  Readable.swift
+//  JamfKit
+//
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+//
+
+/// Represents an object that can be read with an URLRequest
+@objc(JMFKReadable)
+public protocol Readable {
+
+    // MARK: - Functions
+
+    func read() -> URLRequest?
+}

--- a/JamfKit/Sources/Protocols/Requests/Readable.swift
+++ b/JamfKit/Sources/Protocols/Requests/Readable.swift
@@ -7,10 +7,40 @@
 //
 
 /// Represents an object that can be read with an URLRequest
-@objc(JMFKReadable)
 public protocol Readable {
 
     // MARK: - Functions
 
+    /// Returns a GET **URLRequest** based on the JSS object type.
+    static func readAll() -> URLRequest?
+
+    /// Returns a GET **URLRequest** based on the JSS object type & the supplied identifier.
+    static func read(identifier: String) -> URLRequest?
+
+    /// Returns a GET **URLRequest** based on the identifier property of the supplied JSS object.
     func read() -> URLRequest?
+}
+
+// MARK: - Implementation
+
+public extension Readable where Self: Endpoint & Identifiable & Requestable {
+
+    // MARK: - Functions
+
+    static func readAll() -> URLRequest? {
+        return SessionManager.instance.readAllRequest(for: self.Endpoint)
+    }
+
+    static func read(identifier: String) -> URLRequest? {
+        return SessionManager.instance.readRequest(for: self, key: BaseObject.CodingKeys.identifier.rawValue, value: identifier)
+    }
+
+    func read() -> URLRequest? {
+        return SessionManager.instance.readRequest(for: self, key: BaseObject.CodingKeys.identifier.rawValue, value: String(identifier))
+    }
+
+    /// Returns a GET **URLRequest** based on the name property of the supplied JSS object.
+    func readWithName() -> URLRequest? {
+        return SessionManager.instance.readRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: name)
+    }
 }

--- a/JamfKit/Sources/Protocols/Requests/Updatable.swift
+++ b/JamfKit/Sources/Protocols/Requests/Updatable.swift
@@ -7,26 +7,24 @@
 //
 
 /// Represents an object that can be updated with an URLRequest
+@objc(JMFKUpdatable)
 public protocol Updatable {
 
     // MARK: - Functions
 
     /// Returns a PUT **URLRequest** based on the identifier property of the supplied JSS object.
-    func update() -> URLRequest?
+    func updateRequest() -> URLRequest?
 }
 
 // MARK: - Implementation
 
-public extension Updatable where Self: Endpoint & Identifiable & Requestable {
+extension Updatable where Self: Endpoint & Identifiable & Requestable {
 
-    // MARK: - Functions
-
-    func update() -> URLRequest? {
+    func getUpdateRequest() -> URLRequest? {
         return SessionManager.instance.updateRequest(for: self, key: BaseObject.CodingKeys.identifier.rawValue, value: String(identifier))
     }
 
-    /// Returns a PUT **URLRequest** based on the name property of the supplied JSS object.
-    func updateWithName() -> URLRequest? {
+    func getUpdateRequestWithName() -> URLRequest? {
         return SessionManager.instance.updateRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: name)
     }
 }

--- a/JamfKit/Sources/Protocols/Requests/Updatable.swift
+++ b/JamfKit/Sources/Protocols/Requests/Updatable.swift
@@ -7,10 +7,26 @@
 //
 
 /// Represents an object that can be updated with an URLRequest
-@objc(JMFKUpdatable)
 public protocol Updatable {
 
     // MARK: - Functions
 
+    /// Returns a PUT **URLRequest** based on the identifier property of the supplied JSS object.
     func update() -> URLRequest?
+}
+
+// MARK: - Implementation
+
+public extension Updatable where Self: Endpoint & Identifiable & Requestable {
+
+    // MARK: - Functions
+
+    func update() -> URLRequest? {
+        return SessionManager.instance.updateRequest(for: self, key: BaseObject.CodingKeys.identifier.rawValue, value: String(identifier))
+    }
+
+    /// Returns a PUT **URLRequest** based on the name property of the supplied JSS object.
+    func updateWithName() -> URLRequest? {
+        return SessionManager.instance.updateRequest(for: self, key: BaseObject.CodingKeys.name.rawValue, value: name)
+    }
 }

--- a/JamfKit/Sources/Protocols/Requests/Updatable.swift
+++ b/JamfKit/Sources/Protocols/Requests/Updatable.swift
@@ -1,0 +1,16 @@
+//
+//  Updatable.swift
+//  JamfKit
+//
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+//
+
+/// Represents an object that can be updated with an URLRequest
+@objc(JMFKUpdatable)
+public protocol Updatable {
+
+    // MARK: - Functions
+
+    func update() -> URLRequest?
+}

--- a/JamfKit/Sources/Protocols/Subset.swift
+++ b/JamfKit/Sources/Protocols/Subset.swift
@@ -1,0 +1,10 @@
+//
+//  Subset.swift
+//  JamfKit
+//
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+//
+
+/// Represents any JSS object that contains a general object that can identify it.
+public protocol Subset { }

--- a/JamfKit/Sources/Session/Requests/SessionManagerRequests.swift
+++ b/JamfKit/Sources/Session/Requests/SessionManagerRequests.swift
@@ -6,13 +6,13 @@
 //  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
-internal enum HttpHeader: String {
+enum HttpHeader: String {
     case accept = "Accept"
     case authorization = "Authorization"
     case contentType = "Content-Type"
 }
 
-internal enum HeaderContentType: String {
+enum HeaderContentType: String {
     case json = "application/json"
 }
 
@@ -21,7 +21,7 @@ extension SessionManager {
     // MARK: - Functions
 
     /// Returns a Base64 encoded username & password pair to be used for Basic HTTP authentication
-    internal static func computeAuthorizationHeader(from username: String, password: String) -> String {
+    static func computeAuthorizationHeader(from username: String, password: String) -> String {
         guard
             !username.isEmpty,
             !password.isEmpty,
@@ -34,7 +34,7 @@ extension SessionManager {
     }
 
     /// Returns an authentified URLRequst matching the supplied configuration
-    internal func authentifiedRequest(for url: URL, authorizationHeader: String, method: HttpMethod) -> URLRequest {
+    func authentifiedRequest(for url: URL, authorizationHeader: String, method: HttpMethod) -> URLRequest {
         var request = URLRequest(url: url)
         request.httpMethod = method.rawValue
         request.setValue(authorizationHeader, forHTTPHeaderField: HttpHeader.authorization.rawValue)
@@ -42,7 +42,7 @@ extension SessionManager {
         return request
     }
 
-    internal func baseRequest(endpoint: String, key: String, value: String, method: HttpMethod) -> URLRequest? {
+    func baseRequest(endpoint: String, key: String, value: String, method: HttpMethod) -> URLRequest? {
         guard let url = host?.appendingPathComponent("\(endpoint)/\(key.asCleanedKey())/\(value)") else {
             return nil
         }
@@ -56,7 +56,7 @@ extension SessionManager {
 extension SessionManager {
 
     /// Returns a `CREATE` URLRequest for the supplied URL
-    internal func createRequest(for object: Endpoint & Requestable, key: String, value: String) -> URLRequest? {
+    func createRequest(for object: Endpoint & Requestable, key: String, value: String) -> URLRequest? {
         guard
             var request = baseRequest(endpoint: object.endpoint, key: key, value: value, method: .post),
             let data = try? JSONSerialization.data(withJSONObject: object.toJSON(), options: .prettyPrinted) else {
@@ -75,7 +75,7 @@ extension SessionManager {
 extension SessionManager {
 
     /// Returns a `READ` URLRequest for the supplied JSS endpoint
-    internal func readAllRequest(for endpoint: String) -> URLRequest? {
+    func readAllRequest(for endpoint: String) -> URLRequest? {
         guard let url = host?.appendingPathComponent("\(endpoint)") else {
             return nil
         }
@@ -87,7 +87,7 @@ extension SessionManager {
     }
 
     /// Returns a `READ` URLRequest for the supplied endpoint type & identifier
-    internal func readRequest(for endpoint: Endpoint.Type, key: String, value: String) -> URLRequest? {
+    func readRequest(for endpoint: Endpoint.Type, key: String, value: String) -> URLRequest? {
         guard var request = baseRequest(endpoint: endpoint.Endpoint, key: key, value: value, method: .get) else {
             return nil
         }
@@ -98,7 +98,7 @@ extension SessionManager {
     }
 
     /// Returns a `READ` URLRequest for the supplied JSS object
-    internal func readRequest(for object: Endpoint) -> URLRequest? {
+    func readRequest(for object: Endpoint) -> URLRequest? {
         guard let url = host?.appendingPathComponent("\(object.endpoint)") else {
             return nil
         }
@@ -110,7 +110,7 @@ extension SessionManager {
     }
 
     /// Returns a `READ` URLRequest for the supplied JSS object
-    internal func readRequest(for object: Endpoint, key: String, value: String) -> URLRequest? {
+    func readRequest(for object: Endpoint, key: String, value: String) -> URLRequest? {
         guard var request = baseRequest(endpoint: object.endpoint, key: key, value: value, method: .get) else {
             return nil
         }
@@ -126,7 +126,7 @@ extension SessionManager {
 extension SessionManager {
 
     /// Returns an `UPDATE` URLRequest for the supplied JSS object
-    internal func updateRequest(for object: Endpoint & Requestable) -> URLRequest? {
+    func updateRequest(for object: Endpoint & Requestable) -> URLRequest? {
         guard
             let url = host?.appendingPathComponent("\(object.endpoint)"),
             let data = try? JSONSerialization.data(withJSONObject: object.toJSON(), options: .prettyPrinted) else {
@@ -141,7 +141,7 @@ extension SessionManager {
     }
 
     /// Returns an `UPDATE` URLRequest for the supplied JSS object
-    internal func updateRequest(for object: Endpoint & Requestable, key: String, value: String) -> URLRequest? {
+    func updateRequest(for object: Endpoint & Requestable, key: String, value: String) -> URLRequest? {
         guard
             var request = self.baseRequest(endpoint: object.endpoint, key: key, value: value, method: .put),
             let data = try? JSONSerialization.data(withJSONObject: object.toJSON(), options: .prettyPrinted) else {
@@ -160,12 +160,12 @@ extension SessionManager {
 extension SessionManager {
 
     /// Returns a `DELETE` URLRequest for the supplied endpoint type & identifier
-    internal func deleteRequest(for endpoint: Endpoint.Type, key: String, value: String) -> URLRequest? {
+    func deleteRequest(for endpoint: Endpoint.Type, key: String, value: String) -> URLRequest? {
         return baseRequest(endpoint: endpoint.Endpoint, key: key, value: value, method: .delete)
     }
 
     /// Returns a `DELETE` URLRequest for the supplied URL
-    internal func deleteRequest(for object: Endpoint, key: String, value: String) -> URLRequest? {
+    func deleteRequest(for object: Endpoint, key: String, value: String) -> URLRequest? {
         return baseRequest(endpoint: object.endpoint, key: key, value: value, method: .delete)
     }
 }

--- a/JamfKit/Sources/Session/Requests/SessionManagerRequests.swift
+++ b/JamfKit/Sources/Session/Requests/SessionManagerRequests.swift
@@ -2,10 +2,9 @@
 //  JamfKitSessionManagerRequests.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
-
-import Foundation
 
 public enum HttpHeader: String {
     case accept = "Accept"
@@ -40,7 +39,11 @@ extension SessionManager {
     }
 
     /// Returns a `CREATE` URLRequest for the supplied URL
-    internal func createRequest(for url: URL) -> URLRequest {
+    internal func createRequest(for object: Endpoint, key: String = "id", value: String) -> URLRequest? {
+        guard let url = host?.appendingPathComponent("\(object.endpoint)/\(key)/\(value)") else {
+            return nil
+        }
+
         return authentifiedRequest(for: url, authorizationHeader: authorizationHeader, method: HttpMethod.post)
     }
 
@@ -56,6 +59,19 @@ extension SessionManager {
 
     /// Returns a `DELETE` URLRequest for the supplied URL
     internal func deleteRequest(for url: URL) -> URLRequest {
-        return authentifiedRequest(for: url, authorizationHeader: authorizationHeader, method: HttpMethod.delete)
+        return authentifiedRequest(for: url.appendingPathComponent(""), authorizationHeader: authorizationHeader, method: HttpMethod.delete)
+    }
+}
+
+extension SessionManager {
+
+    // MARK: - Functions
+
+    public func request(for object: Requestable & Endpoint, method: HttpMethod = .get, filter: String = "") -> URLRequest? {
+        guard let host = self.host else {
+            return nil
+        }
+
+        return authentifiedRequest(for: host.appendingPathComponent(object.endpoint), authorizationHeader: authorizationHeader, method: method)
     }
 }

--- a/JamfKit/Sources/Session/SessionManager.swift
+++ b/JamfKit/Sources/Session/SessionManager.swift
@@ -2,12 +2,11 @@
 //  HostManager.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
-import Foundation
-
-internal enum HttpMethod: String {
+public enum HttpMethod: String {
     case get = "GET"
     case put = "PUT"
     case post = "POST"
@@ -19,7 +18,7 @@ public final class SessionManager: NSObject {
 
     // MARK: - Properties
 
-    static let instance = SessionManager()
+    public static let instance = SessionManager()
 
     private(set) var host: URL?
     var username: String?

--- a/JamfKit/Sources/Session/SessionManager.swift
+++ b/JamfKit/Sources/Session/SessionManager.swift
@@ -82,23 +82,23 @@ public final class SessionManager: NSObject {
      *
      * - Throws: `SessionManagerErrorCode.incompleteHostConfiguration` if the configuration is not fully specified.
      */
-    public func performConnectivityCheck(completion completionBlock: @escaping (Bool) -> Void) throws {
-        guard let url = host else {
-            throw SessionManagerError(code: .incompleteHostConfiguration)
-        }
-
-        URLSession.shared.dataTask(with: readRequest(for: url)) { (_, response, error) in
-            guard error == nil else {
-                completionBlock(false)
-                return
-            }
-
-            guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
-                completionBlock(false)
-                return
-            }
-
-            completionBlock(true)
-        }.resume()
-    }
+//    public func performConnectivityCheck(completion completionBlock: @escaping (Bool) -> Void) throws {
+//        guard let url = host else {
+//            throw SessionManagerError(code: .incompleteHostConfiguration)
+//        }
+//
+//        URLSession.shared.dataTask(with: readRequest(for: url)) { (_, response, error) in
+//            guard error == nil else {
+//                completionBlock(false)
+//                return
+//            }
+//
+//            guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+//                completionBlock(false)
+//                return
+//            }
+//
+//            completionBlock(true)
+//        }.resume()
+//    }
 }

--- a/JamfKit/Sources/Session/SessionManagerError.swift
+++ b/JamfKit/Sources/Session/SessionManagerError.swift
@@ -29,7 +29,7 @@ public class SessionManagerError: NSError {
 
     // MARK: - Initialization
 
-    convenience internal init(code: SessionManagerErrorCode) {
+    convenience init(code: SessionManagerErrorCode) {
         self.init(domain: Constants.domain, code: code.rawValue)
     }
 }

--- a/JamfKit/Sources/Session/SessionManagerError.swift
+++ b/JamfKit/Sources/Session/SessionManagerError.swift
@@ -2,7 +2,8 @@
 //  SessionManagerError.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 @objc(JMFKSessionManagerErrorCode)

--- a/JamfKit/Test/AppDelegate.h
+++ b/JamfKit/Test/AppDelegate.h
@@ -1,0 +1,17 @@
+//
+//  AppDelegate.h
+//  Test
+//
+//  Created by Damien Rivet on 21.02.18.
+//  Copyright © 2018 JamfKit. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+
+@property (strong, nonatomic) UIWindow *window;
+
+
+@end
+

--- a/JamfKit/Test/AppDelegate.m
+++ b/JamfKit/Test/AppDelegate.m
@@ -1,0 +1,51 @@
+//
+//  AppDelegate.m
+//  Test
+//
+//  Created by Damien Rivet on 21.02.18.
+//  Copyright © 2018 JamfKit. All rights reserved.
+//
+
+#import "AppDelegate.h"
+
+@interface AppDelegate ()
+
+@end
+
+@implementation AppDelegate
+
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    // Override point for customization after application launch.
+    return YES;
+}
+
+
+- (void)applicationWillResignActive:(UIApplication *)application {
+    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+    // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
+}
+
+
+- (void)applicationDidEnterBackground:(UIApplication *)application {
+    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+    // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+}
+
+
+- (void)applicationWillEnterForeground:(UIApplication *)application {
+    // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
+}
+
+
+- (void)applicationDidBecomeActive:(UIApplication *)application {
+    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+}
+
+
+- (void)applicationWillTerminate:(UIApplication *)application {
+    // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+}
+
+
+@end

--- a/JamfKit/Test/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/JamfKit/Test/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,93 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/JamfKit/Test/Base.lproj/LaunchScreen.storyboard
+++ b/JamfKit/Test/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" systemVersion="17A277" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/JamfKit/Test/Base.lproj/Main.storyboard
+++ b/JamfKit/Test/Base.lproj/Main.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" systemVersion="17A277" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/JamfKit/Test/Info.plist
+++ b/JamfKit/Test/Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/JamfKit/Test/ViewController.h
+++ b/JamfKit/Test/ViewController.h
@@ -1,0 +1,15 @@
+//
+//  ViewController.h
+//  Test
+//
+//  Created by Damien Rivet on 21.02.18.
+//  Copyright © 2018 JamfKit. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface ViewController : UIViewController
+
+
+@end
+

--- a/JamfKit/Test/main.m
+++ b/JamfKit/Test/main.m
@@ -1,0 +1,16 @@
+//
+//  main.m
+//  Test
+//
+//  Created by Damien Rivet on 21.02.18.
+//  Copyright © 2018 JamfKit. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "AppDelegate.h"
+
+int main(int argc, char * argv[]) {
+    @autoreleasepool {
+        return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
+    }
+}

--- a/JamfKit/Tests/Extensions/StringExtensionTests.swift
+++ b/JamfKit/Tests/Extensions/StringExtensionTests.swift
@@ -11,7 +11,7 @@ import XCTest
 @testable import JamfKit
 
 class StringExtensionTests: XCTestCase {
-    
+
     // MARK: - Tests
 
     func testShouldReturnCleanedUpKey() {

--- a/JamfKit/Tests/Extensions/StringExtensionTests.swift
+++ b/JamfKit/Tests/Extensions/StringExtensionTests.swift
@@ -1,0 +1,22 @@
+//
+//  StringExtensionTests.swift
+//  JamfKit
+//
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+//
+
+import XCTest
+
+@testable import JamfKit
+
+class StringExtensionTests: XCTestCase {
+    
+    // MARK: - Tests
+
+    func testShouldReturnCleanedUpKey() {
+        let actualValue = ComputerGeneral.SerialNumberKey.asCleanedKey()
+
+        XCTAssertEqual(actualValue, ComputerGeneral.SerialNumberKey.replacingOccurrences(of: "_", with: ""))
+    }
+}

--- a/JamfKit/Tests/Helpers/JSONHelper.swift
+++ b/JamfKit/Tests/Helpers/JSONHelper.swift
@@ -2,7 +2,8 @@
 //  JSONHelper.swift
 //  JamfKit
 //
-//  Copyright © 2017 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 import XCTest

--- a/JamfKit/Tests/Models/BaseObjectTests.swift
+++ b/JamfKit/Tests/Models/BaseObjectTests.swift
@@ -48,4 +48,5 @@ class BaseObjectTests: XCTestCase {
         XCTAssertNotNil(encodedObject)
         XCTAssertEqual(encodedObject?.count, 2)
     }
+
 }

--- a/JamfKit/Tests/Models/BaseObjectTests.swift
+++ b/JamfKit/Tests/Models/BaseObjectTests.swift
@@ -2,7 +2,8 @@
 //  IdentifiableTests.swift
 //  JamfKit
 //
-//  Copyright © 2017 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 import XCTest

--- a/JamfKit/Tests/Models/BuildingTests.swift
+++ b/JamfKit/Tests/Models/BuildingTests.swift
@@ -62,8 +62,4 @@ class BuildingTests: XCTestCase {
         XCTAssertNotNil(encodedObject)
         XCTAssertEqual(encodedObject?.count, 2)
     }
-
-    func testShouldReturnCreateRequest() {
-        
-    }
 }

--- a/JamfKit/Tests/Models/BuildingTests.swift
+++ b/JamfKit/Tests/Models/BuildingTests.swift
@@ -2,7 +2,8 @@
 //  BuildingTests.swift
 //  JamfKit
 //
-//  Copyright © 2017 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 import XCTest
@@ -46,5 +47,9 @@ class BuildingTests: XCTestCase {
 
         XCTAssertNotNil(encodedObject)
         XCTAssertEqual(encodedObject?.count, 2)
+    }
+
+    func testShouldReturnCreateRequest() {
+        
     }
 }

--- a/JamfKit/Tests/Models/BuildingTests.swift
+++ b/JamfKit/Tests/Models/BuildingTests.swift
@@ -20,6 +20,20 @@ class BuildingTests: XCTestCase {
 
     // MARK: - Tests
 
+    func testShouldInstantiate() {
+        let actualValue = Building(identifier: defaultIdentifier, name: defaultName)
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.identifier, defaultIdentifier)
+        XCTAssertEqual(actualValue?.name, defaultName)
+    }
+
+    func testShouldNotInstantiateWithInvalidParameters() {
+        let actualValue = Building(identifier: defaultIdentifier, name: "")
+
+        XCTAssertNil(actualValue)
+    }
+
     func testShouldInitializeFromJSON() {
         let payload = self.payload(for: "building_valid", subfolder: subfolder)!
 

--- a/JamfKit/Tests/Models/Computer/ComputerGeneralTests.swift
+++ b/JamfKit/Tests/Models/Computer/ComputerGeneralTests.swift
@@ -2,7 +2,8 @@
 //  HardwareGeneralTests.swift
 //  JamfKit
 //
-//  Copyright © 2017 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 import XCTest
@@ -150,8 +151,8 @@ class ComputerGeneralTests: XCTestCase {
         XCTAssertNotNil(encodedObject)
         XCTAssertEqual(encodedObject?.count, 34)
 
-        XCTAssertNotNil(encodedObject?[ComputerGeneral.IdentifierKey])
-        XCTAssertNotNil(encodedObject?[ComputerGeneral.NameKey])
+        XCTAssertNotNil(encodedObject?[BaseObject.CodingKeys.identifier.rawValue])
+        XCTAssertNotNil(encodedObject?[BaseObject.CodingKeys.name.rawValue])
         XCTAssertNotNil(encodedObject?[ComputerGeneral.MacAddressKey])
         XCTAssertNotNil(encodedObject?[ComputerGeneral.AlternativeMacAddressKey])
         XCTAssertNotNil(encodedObject?[ComputerGeneral.IpAddressKey])

--- a/JamfKit/Tests/Models/Computer/ComputerGeneralTests.swift
+++ b/JamfKit/Tests/Models/Computer/ComputerGeneralTests.swift
@@ -39,6 +39,12 @@ class ComputerGeneralTests: XCTestCase {
 
     // MARK: - Tests
 
+    func testShouldNotInstantiateWithInvalidParameters() {
+        let actualValue = ComputerGeneral(identifier: defaultIdentifier, name: "")
+
+        XCTAssertNil(actualValue)
+    }
+
     func testShouldInitializeFromJSON() {
         let payload = self.payload(for: "computer_general_valid", subfolder: subfolder)!
 

--- a/JamfKit/Tests/Models/Computer/ComputerLocationTests.swift
+++ b/JamfKit/Tests/Models/Computer/ComputerLocationTests.swift
@@ -2,7 +2,8 @@
 //  LocationTests.swift
 //  JamfKit
 //
-//  Copyright © 2017 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 import XCTest

--- a/JamfKit/Tests/Models/Computer/ComputerPurchasingTests.swift
+++ b/JamfKit/Tests/Models/Computer/ComputerPurchasingTests.swift
@@ -2,7 +2,8 @@
 //  ComputerPurchasingTests.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 import XCTest

--- a/JamfKit/Tests/Models/Computer/ComputerRemoteManagementTests.swift
+++ b/JamfKit/Tests/Models/Computer/ComputerRemoteManagementTests.swift
@@ -2,7 +2,8 @@
 //  ComputerRemoteManagementTests.swift
 //  JamfKit
 //
-//  Copyright © 2017 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 import XCTest

--- a/JamfKit/Tests/Models/Computer/ComputerTests.swift
+++ b/JamfKit/Tests/Models/Computer/ComputerTests.swift
@@ -2,7 +2,8 @@
 //  ComputerTests.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 import XCTest

--- a/JamfKit/Tests/Models/Computer/ComputerTests.swift
+++ b/JamfKit/Tests/Models/Computer/ComputerTests.swift
@@ -15,8 +15,24 @@ class ComputerTests: XCTestCase {
     // MARK: - Constants
 
     let subfolder = "Computer/"
+    let defaultIdentifier: UInt = 12345
+    let defaultName = "computer"
 
     // MARK: - Tests
+
+    func testShouldInstantiate() {
+        let actualValue = Computer(identifier: defaultIdentifier, name: defaultName)
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.general.identifier, defaultIdentifier)
+        XCTAssertEqual(actualValue?.general.name, defaultName)
+    }
+
+    func testShouldNotInstantiateWithInvalidParameters() {
+        let actualValue = Computer(identifier: defaultIdentifier, name: "")
+
+        XCTAssertNil(actualValue)
+    }
 
     func testShouldInitializeFromJSON() {
         let payload = self.payload(for: "computer", subfolder: subfolder)!

--- a/JamfKit/Tests/Models/ComputerCommand/ComputerCommandGeneralTests.swift
+++ b/JamfKit/Tests/Models/ComputerCommand/ComputerCommandGeneralTests.swift
@@ -2,7 +2,8 @@
 //  ComputerCommandGeneralTests.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 import XCTest

--- a/JamfKit/Tests/Models/ComputerCommand/ComputerCommandGeneralTests.swift
+++ b/JamfKit/Tests/Models/ComputerCommand/ComputerCommandGeneralTests.swift
@@ -20,6 +20,20 @@ class ComputerCommandGeneralTests: XCTestCase {
 
     // MARK: - Tests
 
+    func testShouldInstantiate() {
+        let actualValue = ComputerCommandGeneral(command: defaultCommand, passcode: defaultPasscode)
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.command, defaultCommand)
+        XCTAssertEqual(actualValue?.passcode, defaultPasscode)
+    }
+
+    func testShouldNotInstantiateWithInvalidParameters() {
+        let actualValue = ComputerCommandGeneral(command: "", passcode: defaultPasscode)
+
+        XCTAssertNil(actualValue)
+    }
+
     func testShouldInitializeFromJSON() {
         let payload = self.payload(for: "computer_command_general_valid", subfolder: subfolder)!
 

--- a/JamfKit/Tests/Models/ComputerCommand/ComputerCommandTests.swift
+++ b/JamfKit/Tests/Models/ComputerCommand/ComputerCommandTests.swift
@@ -2,7 +2,8 @@
 //  ComputerCommandTests.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 import XCTest

--- a/JamfKit/Tests/Models/ComputerCommand/ComputerCommandTests.swift
+++ b/JamfKit/Tests/Models/ComputerCommand/ComputerCommandTests.swift
@@ -20,6 +20,20 @@ class ComputerCommandTests: XCTestCase {
 
     // MARK: - Tests
 
+    func testShouldInstantiate() {
+        let actualValue = ComputerCommand(command: defaultCommand, passcode: defaultPasscode)
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.general.command, defaultCommand)
+        XCTAssertEqual(actualValue?.general.passcode, defaultPasscode)
+    }
+
+    func testShouldNotInstantiateWithInvalidParameters() {
+        let actualValue = ComputerCommand(command: "", passcode: defaultPasscode)
+
+        XCTAssertNil(actualValue)
+    }
+
     func testShouldInitializeFromJSON() {
         let payload = self.payload(for: "computer_command", subfolder: subfolder)!
 

--- a/JamfKit/Tests/Models/ComputerConfiguration/ComputerConfigurationGeneralTest.swift
+++ b/JamfKit/Tests/Models/ComputerConfiguration/ComputerConfigurationGeneralTest.swift
@@ -24,6 +24,20 @@ class ComputerConfigurationGeneralTest: XCTestCase {
 
     // MARK: - Tests
 
+    func testShouldInstantiate() {
+        let actualValue = ComputerConfigurationGeneral(identifier: defaultIdentifier, name: defaultName)
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.identifier, defaultIdentifier)
+        XCTAssertEqual(actualValue?.name, defaultName)
+    }
+
+    func testShouldNotInstantiateWithInvalidParameters() {
+        let actualValue = ComputerConfigurationGeneral(identifier: defaultIdentifier, name: "")
+
+        XCTAssertNil(actualValue)
+    }
+
     func testShouldInitializeFromJSON() {
         let payload = self.payload(for: "computer_configuration_general_valid", subfolder: subfolder)!
 

--- a/JamfKit/Tests/Models/ComputerConfiguration/ComputerConfigurationGeneralTest.swift
+++ b/JamfKit/Tests/Models/ComputerConfiguration/ComputerConfigurationGeneralTest.swift
@@ -2,7 +2,8 @@
 //  ComputerConfigurationGeneralTest.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 import XCTest
@@ -59,8 +60,9 @@ class ComputerConfigurationGeneralTest: XCTestCase {
 
         XCTAssertNotNil(encodedObject)
         XCTAssertEqual(encodedObject?.count, 12)
-        XCTAssertNotNil(encodedObject?[ComputerConfigurationGeneral.IdentifierKey])
-        XCTAssertNotNil(encodedObject?[ComputerConfigurationGeneral.NameKey])
+
+        XCTAssertNotNil(encodedObject?[BaseObject.CodingKeys.identifier.rawValue])
+        XCTAssertNotNil(encodedObject?[BaseObject.CodingKeys.name.rawValue])
         XCTAssertNotNil(encodedObject?[ComputerConfigurationGeneral.DescriptionKey])
         XCTAssertNotNil(encodedObject?[ComputerConfigurationGeneral.TypeKey])
         XCTAssertNotNil(encodedObject?[ComputerConfigurationGeneral.ParentKey])

--- a/JamfKit/Tests/Models/ComputerConfiguration/ComputerConfigurationManagementTests.swift
+++ b/JamfKit/Tests/Models/ComputerConfiguration/ComputerConfigurationManagementTests.swift
@@ -2,7 +2,8 @@
 //  ComputerConfigurationManagementTests.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 import XCTest

--- a/JamfKit/Tests/Models/ComputerConfiguration/ComputerConfigurationTests.swift
+++ b/JamfKit/Tests/Models/ComputerConfiguration/ComputerConfigurationTests.swift
@@ -15,8 +15,24 @@ class ComputerConfigurationTests: XCTestCase {
     // MARK: - Constants
 
     let subfolder = "ComputerConfiguration/"
+    let defaultIdentifier: UInt = 12345
+    let defaultName = "High Sierra Base OS"
 
     // MARK: - Tests
+
+    func testShouldInstantiate() {
+        let actualValue = ComputerConfiguration(identifier: defaultIdentifier, name: defaultName)
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.general.identifier, defaultIdentifier)
+        XCTAssertEqual(actualValue?.general.name, defaultName)
+    }
+
+    func testShouldNotInstantiateWithInvalidParameters() {
+        let actualValue = ComputerConfiguration(identifier: defaultIdentifier, name: "")
+
+        XCTAssertNil(actualValue)
+    }
 
     func testShouldInitializeFromJSON() {
         let payload = self.payload(for: "computer_configuration", subfolder: subfolder)!

--- a/JamfKit/Tests/Models/ComputerConfiguration/ComputerConfigurationTests.swift
+++ b/JamfKit/Tests/Models/ComputerConfiguration/ComputerConfigurationTests.swift
@@ -2,7 +2,8 @@
 //  ComputerConfigurationTests.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 import XCTest

--- a/JamfKit/Tests/Models/ComputerGroup/ComputerGroupTests.swift
+++ b/JamfKit/Tests/Models/ComputerGroup/ComputerGroupTests.swift
@@ -21,6 +21,20 @@ class ComputerGroupTests: XCTestCase {
 
     // MARK: - Tests
 
+    func testShouldInstantiate() {
+        let actualValue = ComputerGroup(identifier: defaultIdentifier, name: defaultName)
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.identifier, defaultIdentifier)
+        XCTAssertEqual(actualValue?.name, defaultName)
+    }
+
+    func testShouldNotInstantiateWithInvalidParameters() {
+        let actualValue = ComputerGroup(identifier: defaultIdentifier, name: "")
+
+        XCTAssertNil(actualValue)
+    }
+
     func testShouldInitializeFromJSON() {
         let payload = self.payload(for: "computer_group_valid", subfolder: subfolder)!
 

--- a/JamfKit/Tests/Models/ComputerGroup/ComputerGroupTests.swift
+++ b/JamfKit/Tests/Models/ComputerGroup/ComputerGroupTests.swift
@@ -2,7 +2,8 @@
 //  ComputerGroupTests.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 import XCTest
@@ -93,8 +94,8 @@ class ComputerGroupTests: XCTestCase {
 
         XCTAssertNotNil(encodedObject)
         XCTAssertEqual(encodedObject?.count, 6)
-        XCTAssertNotNil(encodedObject?[ComputerGroup.IdentifierKey])
-        XCTAssertNotNil(encodedObject?[ComputerGroup.NameKey])
+        XCTAssertNotNil(encodedObject?[BaseObject.CodingKeys.identifier.rawValue])
+        XCTAssertNotNil(encodedObject?[BaseObject.CodingKeys.name.rawValue])
         XCTAssertNotNil(encodedObject?[ComputerGroup.IsSmartKey])
         XCTAssertNotNil(encodedObject?[ComputerGroup.CriteriaKey])
         XCTAssertNotNil(encodedObject?[ComputerGroup.SiteKey])

--- a/JamfKit/Tests/Models/DepartmentTests.swift
+++ b/JamfKit/Tests/Models/DepartmentTests.swift
@@ -20,6 +20,20 @@ class DepartmentTests: XCTestCase {
 
     // MARK: - Tests
 
+    func testShouldInstantiate() {
+        let actualValue = Department(identifier: defaultIdentifier, name: defaultName)
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.identifier, defaultIdentifier)
+        XCTAssertEqual(actualValue?.name, defaultName)
+    }
+
+    func testShouldNotInstantiateWithInvalidParameters() {
+        let actualValue = Department(identifier: defaultIdentifier, name: "")
+
+        XCTAssertNil(actualValue)
+    }
+
     func testShouldInitializeFromJSON() {
         let payload = self.payload(for: "department_valid", subfolder: subfolder)!
 

--- a/JamfKit/Tests/Models/DepartmentTests.swift
+++ b/JamfKit/Tests/Models/DepartmentTests.swift
@@ -2,7 +2,8 @@
 //  DepartmentTests.swift
 //  JamfKit
 //
-//  Copyright © 2017 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 import XCTest

--- a/JamfKit/Tests/Models/DirectoryBindingTests.swift
+++ b/JamfKit/Tests/Models/DirectoryBindingTests.swift
@@ -26,6 +26,20 @@ class DirectoryBindingTests: XCTestCase {
 
     // MARK: - Tests
 
+    func testShouldInstantiate() {
+        let actualValue = DirectoryBinding(identifier: defaultIdentifier, name: defaultName)
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.identifier, defaultIdentifier)
+        XCTAssertEqual(actualValue?.name, defaultName)
+    }
+
+    func testShouldNotInstantiateWithInvalidParameters() {
+        let actualValue = DirectoryBinding(identifier: defaultIdentifier, name: "")
+
+        XCTAssertNil(actualValue)
+    }
+
     func testShouldInitializeFromJSON() {
         let payload = self.payload(for: "directory_binding_valid", subfolder: subfolder)!
 

--- a/JamfKit/Tests/Models/DirectoryBindingTests.swift
+++ b/JamfKit/Tests/Models/DirectoryBindingTests.swift
@@ -2,7 +2,8 @@
 //  DirectoryBindingTests.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 import XCTest
@@ -76,8 +77,8 @@ class DirectoryBindingTests: XCTestCase {
         XCTAssertNotNil(encodedObject)
         XCTAssertEqual(encodedObject?.count, 8)
 
-        XCTAssertNotNil(encodedObject?[DirectoryBinding.IdentifierKey])
-        XCTAssertNotNil(encodedObject?[DirectoryBinding.NameKey])
+        XCTAssertNotNil(encodedObject?[BaseObject.CodingKeys.identifier.rawValue])
+        XCTAssertNotNil(encodedObject?[BaseObject.CodingKeys.name.rawValue])
         XCTAssertNotNil(encodedObject?[DirectoryBinding.PriorityKey])
         XCTAssertNotNil(encodedObject?[DirectoryBinding.DomainKey])
         XCTAssertNotNil(encodedObject?[DirectoryBinding.UsernameKey])

--- a/JamfKit/Tests/Models/HardwareGroup/HardwareGroupCriterionTests.swift
+++ b/JamfKit/Tests/Models/HardwareGroup/HardwareGroupCriterionTests.swift
@@ -2,7 +2,8 @@
 //  MobileDeviceGroupCriterionTests.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 import XCTest

--- a/JamfKit/Tests/Models/HardwareGroup/HardwareGroupCriterionTests.swift
+++ b/JamfKit/Tests/Models/HardwareGroup/HardwareGroupCriterionTests.swift
@@ -25,6 +25,19 @@ class HardwareGroupCriterionTests: XCTestCase {
 
     // MARK: - Tests
 
+    func testShouldInstantiate() {
+        let actualValue = HardwareGroupCriterion(name: defaultName)
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.name, defaultName)
+    }
+
+    func testShouldNotInstantiateWithInvalidParameters() {
+        let actualValue = HardwareGroupCriterion(name: "")
+
+        XCTAssertNil(actualValue)
+    }
+
     func testShouldInitializeFromJSON() {
         let payload = self.payload(for: "hardware_group_criterion", subfolder: subfolder)!
 

--- a/JamfKit/Tests/Models/HardwareGroup/HardwareGroupTests.swift
+++ b/JamfKit/Tests/Models/HardwareGroup/HardwareGroupTests.swift
@@ -11,7 +11,7 @@ import XCTest
 @testable import JamfKit
 
 class HardwareGroupTests: XCTestCase {
-    
+
     // MARK: - Constants
 
     let subfolder = "ComputerGroup/"

--- a/JamfKit/Tests/Models/HardwareGroup/HardwareGroupTests.swift
+++ b/JamfKit/Tests/Models/HardwareGroup/HardwareGroupTests.swift
@@ -1,0 +1,37 @@
+//
+//  HardwareGroupTests.swift
+//  JamfKit
+//
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+//
+
+import XCTest
+
+@testable import JamfKit
+
+class HardwareGroupTests: XCTestCase {
+    
+    // MARK: - Constants
+
+    let subfolder = "ComputerGroup/"
+    let defaultIdentifier: UInt = 12345
+    let defaultName = "computers"
+    let defaultIsSmart = true
+
+    // MARK: - Tests
+
+    func testShouldInstantiate() {
+        let actualValue = HardwareGroup(identifier: defaultIdentifier, name: defaultName)
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.identifier, defaultIdentifier)
+        XCTAssertEqual(actualValue?.name, defaultName)
+    }
+
+    func testShouldNotInstantiateWithInvalidParameters() {
+        let actualValue = HardwareGroup(identifier: defaultIdentifier, name: "")
+
+        XCTAssertNil(actualValue)
+    }
+}

--- a/JamfKit/Tests/Models/MobileDevice/MobileDeviceGeneralTests.swift
+++ b/JamfKit/Tests/Models/MobileDevice/MobileDeviceGeneralTests.swift
@@ -2,7 +2,8 @@
 //  MobileDeviceGeneralTests.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 import XCTest
@@ -202,8 +203,8 @@ class MobileDeviceGeneralTests: XCTestCase {
         XCTAssertNotNil(encodedObject)
         XCTAssertEqual(encodedObject?.count, 48)
         
-        XCTAssertNotNil(encodedObject?[MobileDeviceGeneral.IdentifierKey])
-        XCTAssertNotNil(encodedObject?[MobileDeviceGeneral.NameKey])
+        XCTAssertNotNil(encodedObject?[BaseObject.CodingKeys.identifier.rawValue])
+        XCTAssertNotNil(encodedObject?[BaseObject.CodingKeys.name.rawValue])
         XCTAssertNotNil(encodedObject?[MobileDeviceGeneral.DeviceNameKey])
         XCTAssertNotNil(encodedObject?[MobileDeviceGeneral.AssetTagNameKey])
         XCTAssertNotNil(encodedObject?[MobileDeviceGeneral.LastInventoryUpdateKey])

--- a/JamfKit/Tests/Models/MobileDevice/MobileDeviceGeneralTests.swift
+++ b/JamfKit/Tests/Models/MobileDevice/MobileDeviceGeneralTests.swift
@@ -208,7 +208,7 @@ class MobileDeviceGeneralTests: XCTestCase {
 
         XCTAssertNotNil(encodedObject)
         XCTAssertEqual(encodedObject?.count, 48)
-        
+
         XCTAssertNotNil(encodedObject?[BaseObject.CodingKeys.identifier.rawValue])
         XCTAssertNotNil(encodedObject?[BaseObject.CodingKeys.name.rawValue])
         XCTAssertNotNil(encodedObject?[MobileDeviceGeneral.DeviceNameKey])

--- a/JamfKit/Tests/Models/MobileDevice/MobileDeviceGeneralTests.swift
+++ b/JamfKit/Tests/Models/MobileDevice/MobileDeviceGeneralTests.swift
@@ -55,6 +55,12 @@ class MobileDeviceGeneralTests: XCTestCase {
 
     // MARK: - Tests
 
+    func testShouldNotInstantiateWithInvalidParameters() {
+        let actualValue = MobileDeviceGeneral(identifier: defaultIdentifier, name: "")
+
+        XCTAssertNil(actualValue)
+    }
+
     func testShouldInitializeFromJSON() {
         let payload = self.payload(for: "mobile_device_general_valid", subfolder: subfolder)!
 

--- a/JamfKit/Tests/Models/MobileDevice/MobileDeviceTests.swift
+++ b/JamfKit/Tests/Models/MobileDevice/MobileDeviceTests.swift
@@ -2,7 +2,8 @@
 //  MobileDeviceTests.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 import XCTest

--- a/JamfKit/Tests/Models/MobileDevice/MobileDeviceTests.swift
+++ b/JamfKit/Tests/Models/MobileDevice/MobileDeviceTests.swift
@@ -15,8 +15,24 @@ class MobileDeviceTests: XCTestCase {
     // MARK: - Constants
 
     let subfolder = "MobileDevice/"
+    let defaultIdentifier: UInt = 12345
+    let defaultName = "computer"
 
     // MARK: - Tests
+
+    func testShouldInstantiate() {
+        let actualValue = MobileDevice(identifier: defaultIdentifier, name: defaultName)
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.general.identifier, defaultIdentifier)
+        XCTAssertEqual(actualValue?.general.name, defaultName)
+    }
+
+    func testShouldNotInstantiateWithInvalidParameters() {
+        let actualValue = MobileDevice(identifier: defaultIdentifier, name: "")
+
+        XCTAssertNil(actualValue)
+    }
 
     func testShouldInitializeFromJSON() {
         let payload = self.payload(for: "mobile_device", subfolder: subfolder)!

--- a/JamfKit/Tests/Models/MobileDeviceGroup/MobileDeviceGroupTests.swift
+++ b/JamfKit/Tests/Models/MobileDeviceGroup/MobileDeviceGroupTests.swift
@@ -2,7 +2,8 @@
 //  MobileDeviceGroup.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 import XCTest
@@ -93,8 +94,8 @@ class MobileDeviceGroupTests: XCTestCase {
 
         XCTAssertNotNil(encodedObject)
         XCTAssertEqual(encodedObject?.count, 6)
-        XCTAssertNotNil(encodedObject?[MobileDeviceGroup.IdentifierKey])
-        XCTAssertNotNil(encodedObject?[MobileDeviceGroup.NameKey])
+        XCTAssertNotNil(encodedObject?[BaseObject.CodingKeys.identifier.rawValue])
+        XCTAssertNotNil(encodedObject?[BaseObject.CodingKeys.name.rawValue])
         XCTAssertNotNil(encodedObject?[MobileDeviceGroup.IsSmartKey])
         XCTAssertNotNil(encodedObject?[MobileDeviceGroup.CriteriaKey])
         XCTAssertNotNil(encodedObject?[MobileDeviceGroup.SiteKey])

--- a/JamfKit/Tests/Models/MobileDeviceGroup/MobileDeviceGroupTests.swift
+++ b/JamfKit/Tests/Models/MobileDeviceGroup/MobileDeviceGroupTests.swift
@@ -21,6 +21,20 @@ class MobileDeviceGroupTests: XCTestCase {
 
     // MARK: - Tests
 
+    func testShouldInstantiate() {
+        let actualValue = MobileDeviceGroup(identifier: defaultIdentifier, name: defaultName)
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.identifier, defaultIdentifier)
+        XCTAssertEqual(actualValue?.name, defaultName)
+    }
+
+    func testShouldNotInstantiateWithInvalidParameters() {
+        let actualValue = MobileDeviceGroup(identifier: defaultIdentifier, name: "")
+
+        XCTAssertNil(actualValue)
+    }
+
     func testShouldInitializeFromJSON() {
         let payload = self.payload(for: "mobile_device_group_valid", subfolder: subfolder)!
 

--- a/JamfKit/Tests/Models/NetbootServerTests.swift
+++ b/JamfKit/Tests/Models/NetbootServerTests.swift
@@ -2,7 +2,8 @@
 //  NetbootServerTests.swift
 //  JamfKit
 //
-//  Copyright © 2017 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 import XCTest
@@ -94,8 +95,8 @@ class NetbootServerTests: XCTestCase {
         XCTAssertNotNil(encodedObject)
         XCTAssertEqual(encodedObject?.count, 14)
 
-        XCTAssertNotNil(encodedObject?[NetbootServer.IdentifierKey])
-        XCTAssertNotNil(encodedObject?[NetbootServer.NameKey])
+        XCTAssertNotNil(encodedObject?[BaseObject.CodingKeys.identifier.rawValue])
+        XCTAssertNotNil(encodedObject?[BaseObject.CodingKeys.name.rawValue])
         XCTAssertNotNil(encodedObject?[NetbootServer.IpAddressKey])
         XCTAssertNotNil(encodedObject?[NetbootServer.DefaultImageKey])
         XCTAssertNotNil(encodedObject?[NetbootServer.SpecificImageKey])

--- a/JamfKit/Tests/Models/NetbootServerTests.swift
+++ b/JamfKit/Tests/Models/NetbootServerTests.swift
@@ -32,6 +32,20 @@ class NetbootServerTests: XCTestCase {
 
     // MARK: - Tests
 
+    func testShouldInstantiate() {
+        let actualValue = NetbootServer(identifier: defaultIdentifier, name: defaultName)
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.identifier, defaultIdentifier)
+        XCTAssertEqual(actualValue?.name, defaultName)
+    }
+
+    func testShouldNotInstantiateWithInvalidParameters() {
+        let actualValue = NetbootServer(identifier: defaultIdentifier, name: "")
+
+        XCTAssertNil(actualValue)
+    }
+
     func testShouldInitializeFromJSON() {
         let payload = self.payload(for: "netboot_server_valid", subfolder: subfolder)!
 

--- a/JamfKit/Tests/Models/NetworkSegmentTests.swift
+++ b/JamfKit/Tests/Models/NetworkSegmentTests.swift
@@ -2,7 +2,8 @@
 //  NetworkSegmentTests.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 import XCTest
@@ -77,8 +78,8 @@ class NetworkSegmentTests: XCTestCase {
 
         XCTAssertNotNil(encodedObject)
         XCTAssertEqual(encodedObject?.count, 13)
-        XCTAssertNotNil(encodedObject?[NetworkSegment.IdentifierKey])
-        XCTAssertNotNil(encodedObject?[NetworkSegment.NameKey])
+        XCTAssertNotNil(encodedObject?[BaseObject.CodingKeys.identifier.rawValue])
+        XCTAssertNotNil(encodedObject?[BaseObject.CodingKeys.name.rawValue])
         XCTAssertNotNil(encodedObject?[NetworkSegment.StartingAddressKey])
         XCTAssertNotNil(encodedObject?[NetworkSegment.EndingAddressKey])
         XCTAssertNotNil(encodedObject?[NetworkSegment.DistributionServerKey])

--- a/JamfKit/Tests/Models/NetworkSegmentTests.swift
+++ b/JamfKit/Tests/Models/NetworkSegmentTests.swift
@@ -31,6 +31,20 @@ class NetworkSegmentTests: XCTestCase {
 
     // MARK: - Tests
 
+    func testShouldInstantiate() {
+        let actualValue = NetworkSegment(identifier: defaultIdentifier, name: defaultName)
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.identifier, defaultIdentifier)
+        XCTAssertEqual(actualValue?.name, defaultName)
+    }
+
+    func testShouldNotInstantiateWithInvalidParameters() {
+        let actualValue = NetworkSegment(identifier: defaultIdentifier, name: "")
+
+        XCTAssertNil(actualValue)
+    }
+
     func testShouldInitializeFromJSON() {
         let payload = self.payload(for: "network_segment_valid", subfolder: subfolder)!
 

--- a/JamfKit/Tests/Models/PackageTests.swift
+++ b/JamfKit/Tests/Models/PackageTests.swift
@@ -37,6 +37,20 @@ class PackageTests: XCTestCase {
 
     // MARK: - Tests
 
+    func testShouldInstantiate() {
+        let actualValue = Package(identifier: defaultIdentifier, name: defaultName)
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.identifier, defaultIdentifier)
+        XCTAssertEqual(actualValue?.name, defaultName)
+    }
+
+    func testShouldNotInstantiateWithInvalidParameters() {
+        let actualValue = Package(identifier: defaultIdentifier, name: "")
+
+        XCTAssertNil(actualValue)
+    }
+
     func testShouldInitializeFromJSON() {
         let payload = self.payload(for: "package_valid", subfolder: subfolder)!
 

--- a/JamfKit/Tests/Models/PackageTests.swift
+++ b/JamfKit/Tests/Models/PackageTests.swift
@@ -2,7 +2,8 @@
 //  PackageTests.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 import XCTest
@@ -109,8 +110,8 @@ class PackageTests: XCTestCase {
         XCTAssertNotNil(encodedObject)
         XCTAssertEqual(encodedObject?.count, 19)
 
-        XCTAssertNotNil(encodedObject?[Package.IdentifierKey])
-        XCTAssertNotNil(encodedObject?[Package.NameKey])
+        XCTAssertNotNil(encodedObject?[BaseObject.CodingKeys.identifier.rawValue])
+        XCTAssertNotNil(encodedObject?[BaseObject.CodingKeys.name.rawValue])
         XCTAssertNotNil(encodedObject?[Package.CategoryKey])
         XCTAssertNotNil(encodedObject?[Package.FilenameKey])
         XCTAssertNotNil(encodedObject?[Package.InformationKey])

--- a/JamfKit/Tests/Models/PartitionTests.swift
+++ b/JamfKit/Tests/Models/PartitionTests.swift
@@ -26,6 +26,19 @@ class PartitionTests: XCTestCase {
 
     // MARK: - Tests
 
+    func testShouldInstantiate() {
+        let actualValue = Partition(name: defaultName)
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.name, defaultName)
+    }
+
+    func testShouldNotInstantiateWithInvalidParameters() {
+        let actualValue = Partition(name: "")
+
+        XCTAssertNil(actualValue)
+    }
+
     func testShouldInitializeFromJSON() {
         let payload = self.payload(for: "partition", subfolder: subfolder)!
 

--- a/JamfKit/Tests/Models/PartitionTests.swift
+++ b/JamfKit/Tests/Models/PartitionTests.swift
@@ -2,7 +2,8 @@
 //  PartitionTests.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 import XCTest

--- a/JamfKit/Tests/Models/Policy/PolicyCategoryTests.swift
+++ b/JamfKit/Tests/Models/Policy/PolicyCategoryTests.swift
@@ -2,7 +2,8 @@
 //  PolicyCategoryTests.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 import XCTest
@@ -47,8 +48,9 @@ class PolicyCategoryTests: XCTestCase {
 
         XCTAssertNotNil(encodedObject)
         XCTAssertEqual(encodedObject?.count, 3)
-        XCTAssertNotNil(encodedObject?[PolicyCategory.IdentifierKey])
-        XCTAssertNotNil(encodedObject?[PolicyCategory.NameKey])
+
+        XCTAssertNotNil(encodedObject?[BaseObject.CodingKeys.identifier.rawValue])
+        XCTAssertNotNil(encodedObject?[BaseObject.CodingKeys.name.rawValue])
         XCTAssertNotNil(encodedObject?[PolicyCategory.PriorityKey])
     }
 }

--- a/JamfKit/Tests/Models/Policy/PolicyCategoryTests.swift
+++ b/JamfKit/Tests/Models/Policy/PolicyCategoryTests.swift
@@ -21,6 +21,20 @@ class PolicyCategoryTests: XCTestCase {
 
     // MARK: - Tests
 
+    func testShouldInstantiate() {
+        let actualValue = PolicyCategory(identifier: defaultIdentifier, name: defaultName)
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.identifier, defaultIdentifier)
+        XCTAssertEqual(actualValue?.name, defaultName)
+    }
+
+    func testShouldNotInstantiateWithInvalidParameters() {
+        let actualValue = PolicyCategory(identifier: defaultIdentifier, name: "")
+
+        XCTAssertNil(actualValue)
+    }
+
     func testShouldInitializeFromJSON() {
         let payload = self.payload(for: "policy_category_valid", subfolder: subfolder)!
 

--- a/JamfKit/Tests/Models/Policy/PolicyDateTimeLimitationsTests.swift
+++ b/JamfKit/Tests/Models/Policy/PolicyDateTimeLimitationsTests.swift
@@ -2,7 +2,8 @@
 //  PolicyDateTimeLimitationsTests.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 import XCTest

--- a/JamfKit/Tests/Models/Policy/PolicyGeneralTests.swift
+++ b/JamfKit/Tests/Models/Policy/PolicyGeneralTests.swift
@@ -3,7 +3,8 @@
 //  PolicyGeneralTests.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 import XCTest
@@ -109,8 +110,8 @@ class PolicyGeneralTests: XCTestCase {
         XCTAssertNotNil(encodedObject)
         XCTAssertEqual(encodedObject?.count, 21)
 
-        XCTAssertNotNil(encodedObject?[PolicyGeneral.IdentifierKey])
-        XCTAssertNotNil(encodedObject?[PolicyGeneral.NameKey])
+        XCTAssertNotNil(encodedObject?[BaseObject.CodingKeys.identifier.rawValue])
+        XCTAssertNotNil(encodedObject?[BaseObject.CodingKeys.name.rawValue])
         XCTAssertNotNil(encodedObject?[PolicyGeneral.EnabledKey])
         XCTAssertNotNil(encodedObject?[PolicyGeneral.TriggerKey])
         XCTAssertNotNil(encodedObject?[PolicyGeneral.TriggerCheckinKey])

--- a/JamfKit/Tests/Models/Policy/PolicyGeneralTests.swift
+++ b/JamfKit/Tests/Models/Policy/PolicyGeneralTests.swift
@@ -1,4 +1,3 @@
-
 //
 //  PolicyGeneralTests.swift
 //  JamfKit

--- a/JamfKit/Tests/Models/Policy/PolicyGeneralTests.swift
+++ b/JamfKit/Tests/Models/Policy/PolicyGeneralTests.swift
@@ -35,6 +35,20 @@ class PolicyGeneralTests: XCTestCase {
 
     // MARK: - Tests
 
+    func testShouldInstantiate() {
+        let actualValue = PolicyGeneral(identifier: defaultIdentifier, name: defaultName)
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.identifier, defaultIdentifier)
+        XCTAssertEqual(actualValue?.name, defaultName)
+    }
+
+    func testShouldNotInstantiateWithInvalidParameters() {
+        let actualValue = PolicyGeneral(identifier: defaultIdentifier, name: "")
+
+        XCTAssertNil(actualValue)
+    }
+
     func testShouldInitializeFromJSON() {
         let payload = self.payload(for: "policy_general_valid", subfolder: subfolder)!
 

--- a/JamfKit/Tests/Models/Policy/PolicyNetworkLimitationsTests.swift
+++ b/JamfKit/Tests/Models/Policy/PolicyNetworkLimitationsTests.swift
@@ -2,7 +2,8 @@
 //  PolicyNetworkLimitationsTests.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 import XCTest

--- a/JamfKit/Tests/Models/Policy/PolicyOverrideDefaultSettingsTests.swift
+++ b/JamfKit/Tests/Models/Policy/PolicyOverrideDefaultSettingsTests.swift
@@ -2,7 +2,8 @@
 //  PolicyOverrideDefaultSettingsTests.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 import XCTest

--- a/JamfKit/Tests/Models/Policy/PolicyTests.swift
+++ b/JamfKit/Tests/Models/Policy/PolicyTests.swift
@@ -2,7 +2,8 @@
 //  PolicyTests.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 import XCTest

--- a/JamfKit/Tests/Models/Policy/PolicyTests.swift
+++ b/JamfKit/Tests/Models/Policy/PolicyTests.swift
@@ -15,8 +15,24 @@ class PolicyTests: XCTestCase {
     // MARK: - Constants
 
     let subfolder = "Policy/"
+    let defaultIdentifier: UInt = 12345
+    let defaultName = "policy"
 
     // MARK: - Tests
+
+    func testShouldInstantiate() {
+        let actualValue = Policy(identifier: defaultIdentifier, name: defaultName)
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.general.identifier, defaultIdentifier)
+        XCTAssertEqual(actualValue?.general.name, defaultName)
+    }
+
+    func testShouldNotInstantiateWithInvalidParameters() {
+        let actualValue = Policy(identifier: defaultIdentifier, name: "")
+
+        XCTAssertNil(actualValue)
+    }
 
     func testShouldInitializeFromJSON() {
         let payload = self.payload(for: "policy", subfolder: subfolder)!

--- a/JamfKit/Tests/Models/PreciseDateTests.swift
+++ b/JamfKit/Tests/Models/PreciseDateTests.swift
@@ -2,7 +2,8 @@
 //  PreciseDateTests.swift
 //  JamfKit
 //
-//  Copyright © 2017 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 import XCTest

--- a/JamfKit/Tests/Models/PrinterTests.swift
+++ b/JamfKit/Tests/Models/PrinterTests.swift
@@ -32,6 +32,20 @@ class PrinterTests: XCTestCase {
 
     // MARK: - Tests
 
+    func testShouldInstantiate() {
+        let actualValue = Printer(identifier: defaultIdentifier, name: defaultName)
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.identifier, defaultIdentifier)
+        XCTAssertEqual(actualValue?.name, defaultName)
+    }
+
+    func testShouldNotInstantiateWithInvalidParameters() {
+        let actualValue = Printer(identifier: defaultIdentifier, name: "")
+
+        XCTAssertNil(actualValue)
+    }
+
     func testShouldInitializeFromJSON() {
         let payload = self.payload(for: "printer_valid", subfolder: subfolder)!
 

--- a/JamfKit/Tests/Models/PrinterTests.swift
+++ b/JamfKit/Tests/Models/PrinterTests.swift
@@ -2,7 +2,8 @@
 //  PrinterTests.swift
 //  JamfKit
 //
-//  Copyright © 2017 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 import XCTest
@@ -94,8 +95,8 @@ class PrinterTests: XCTestCase {
         XCTAssertNotNil(encodedObject)
         XCTAssertEqual(encodedObject?.count, 14)
 
-        XCTAssertNotNil(encodedObject?[Printer.IdentifierKey])
-        XCTAssertNotNil(encodedObject?[Printer.NameKey])
+        XCTAssertNotNil(encodedObject?[BaseObject.CodingKeys.identifier.rawValue])
+        XCTAssertNotNil(encodedObject?[BaseObject.CodingKeys.name.rawValue])
         XCTAssertNotNil(encodedObject?[Printer.CategoryKey])
         XCTAssertNotNil(encodedObject?[Printer.UriKey])
         XCTAssertNotNil(encodedObject?[Printer.CupsNameKey])

--- a/JamfKit/Tests/Models/SMTPServerTests.swift
+++ b/JamfKit/Tests/Models/SMTPServerTests.swift
@@ -2,7 +2,8 @@
 //  SMTPServerTests.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 import XCTest

--- a/JamfKit/Tests/Models/SMTPServerTests.swift
+++ b/JamfKit/Tests/Models/SMTPServerTests.swift
@@ -29,6 +29,20 @@ class SMTPServerTests: XCTestCase {
 
     // MARK: - Tests
 
+    func testShouldInstantiate() {
+        let actualValue = SMTPServer(host: defaultHost, port: defaultPort)
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.host, defaultHost)
+        XCTAssertEqual(actualValue?.port, defaultPort)
+    }
+
+    func testShouldNotInstantiateWithInvalidParameters() {
+        let actualValue = SMTPServer(host: "", port: defaultPort)
+
+        XCTAssertNil(actualValue)
+    }
+
     func testShouldInitializeFromJSON() {
         let payload = self.payload(for: "smtp_server", subfolder: subfolder)!
 

--- a/JamfKit/Tests/Models/ScriptTests.swift
+++ b/JamfKit/Tests/Models/ScriptTests.swift
@@ -38,6 +38,20 @@ class ScriptTests: XCTestCase {
 
     // MARK: - Tests
 
+    func testShouldInstantiate() {
+        let actualValue = Script(identifier: defaultIdentifier, name: defaultName)
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.identifier, defaultIdentifier)
+        XCTAssertEqual(actualValue?.name, defaultName)
+    }
+
+    func testShouldNotInstantiateWithInvalidParameters() {
+        let actualValue = Script(identifier: defaultIdentifier, name: "")
+
+        XCTAssertNil(actualValue)
+    }
+
     func testShouldInitializeFromJSON() {
         let payload = self.payload(for: "script_valid", subfolder: subfolder)!
 

--- a/JamfKit/Tests/Models/ScriptTests.swift
+++ b/JamfKit/Tests/Models/ScriptTests.swift
@@ -2,7 +2,8 @@
 //  ScriptTests.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 import XCTest
@@ -94,8 +95,8 @@ class ScriptTests: XCTestCase {
         XCTAssertNotNil(encodedObject)
         XCTAssertEqual(encodedObject?.count, 11)
 
-        XCTAssertNotNil(encodedObject?[Script.IdentifierKey])
-        XCTAssertNotNil(encodedObject?[Script.NameKey])
+        XCTAssertNotNil(encodedObject?[BaseObject.CodingKeys.identifier.rawValue])
+        XCTAssertNotNil(encodedObject?[BaseObject.CodingKeys.name.rawValue])
         XCTAssertNotNil(encodedObject?[Script.CategoryKey])
         XCTAssertNotNil(encodedObject?[Script.FilenameKey])
         XCTAssertNotNil(encodedObject?[Script.InfoKey])

--- a/JamfKit/Tests/Models/SiteTests.swift
+++ b/JamfKit/Tests/Models/SiteTests.swift
@@ -2,7 +2,8 @@
 //  SiteTests.swift
 //  JamfKit
 //
-//  Copyright © 2017 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 import XCTest

--- a/JamfKit/Tests/Models/SiteTests.swift
+++ b/JamfKit/Tests/Models/SiteTests.swift
@@ -20,6 +20,20 @@ class SiteTests: XCTestCase {
 
     // MARK: - Tests
 
+    func testShouldInstantiate() {
+        let actualValue = Site(identifier: defaultIdentifier, name: defaultName)
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.identifier, defaultIdentifier)
+        XCTAssertEqual(actualValue?.name, defaultName)
+    }
+
+    func testShouldNotInstantiateWithInvalidParameters() {
+        let actualValue = Site(identifier: defaultIdentifier, name: "")
+
+        XCTAssertNil(actualValue)
+    }
+
     func testShouldInitializeFromJSON() {
         let payload = self.payload(for: "site_valid", subfolder: subfolder)!
 

--- a/JamfKit/Tests/Models/UserTests.swift
+++ b/JamfKit/Tests/Models/UserTests.swift
@@ -2,7 +2,8 @@
 //  UserTests.swift
 //  JamfKit
 //
-//  Copyright © 2017 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 import XCTest
@@ -99,8 +100,9 @@ class UserTests: XCTestCase {
 
         XCTAssertNotNil(encodedObject)
         XCTAssertEqual(encodedObject?.count, 10)
-        XCTAssertNotNil(encodedObject?[User.IdentifierKey])
-        XCTAssertNotNil(encodedObject?[User.NameKey])
+        
+        XCTAssertNotNil(encodedObject?[BaseObject.CodingKeys.identifier.rawValue])
+        XCTAssertNotNil(encodedObject?[BaseObject.CodingKeys.name.rawValue])
         XCTAssertNotNil(encodedObject?[User.FullNameKey])
         XCTAssertNotNil(encodedObject?[User.EmailKey])
         XCTAssertNotNil(encodedObject?[User.EmailAddressKey])

--- a/JamfKit/Tests/Models/UserTests.swift
+++ b/JamfKit/Tests/Models/UserTests.swift
@@ -114,7 +114,7 @@ class UserTests: XCTestCase {
 
         XCTAssertNotNil(encodedObject)
         XCTAssertEqual(encodedObject?.count, 10)
-        
+
         XCTAssertNotNil(encodedObject?[BaseObject.CodingKeys.identifier.rawValue])
         XCTAssertNotNil(encodedObject?[BaseObject.CodingKeys.name.rawValue])
         XCTAssertNotNil(encodedObject?[User.FullNameKey])

--- a/JamfKit/Tests/Models/UserTests.swift
+++ b/JamfKit/Tests/Models/UserTests.swift
@@ -27,6 +27,20 @@ class UserTests: XCTestCase {
 
     // MARK: - Tests
 
+    func testShouldInstantiate() {
+        let actualValue = User(identifier: defaultIdentifier, name: defaultName)
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.identifier, defaultIdentifier)
+        XCTAssertEqual(actualValue?.name, defaultName)
+    }
+
+    func testShouldNotInstantiateWithInvalidParameters() {
+        let actualValue = User(identifier: defaultIdentifier, name: "")
+
+        XCTAssertNil(actualValue)
+    }
+
     func testShouldInitializeFromJSON() {
         let payload = self.payload(for: "user_valid", subfolder: subfolder)!
 
@@ -35,7 +49,7 @@ class UserTests: XCTestCase {
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.identifier, defaultIdentifier)
         XCTAssertEqual(actualValue?.name, defaultName)
-        XCTAssertEqual(actualValue?.description, "[User][\(defaultIdentifier) - \(defaultFullName)]")
+        XCTAssertEqual(actualValue?.description, "[User][\(defaultIdentifier) - \(defaultName)][\(defaultFullName)]")
         XCTAssertEqual(actualValue?.fullName, defaultFullName)
         XCTAssertEqual(actualValue?.email, defaultEmail)
         XCTAssertEqual(actualValue?.emailAddress, defaultEmailAddress)
@@ -54,7 +68,7 @@ class UserTests: XCTestCase {
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.identifier, defaultIdentifier)
         XCTAssertEqual(actualValue?.name, defaultName)
-        XCTAssertEqual(actualValue?.description, "[User][\(defaultIdentifier) - ]")
+        XCTAssertEqual(actualValue?.description, "[User][\(defaultIdentifier) - \(defaultName)]")
         XCTAssertEqual(actualValue?.fullName, "")
         XCTAssertEqual(actualValue?.email, "")
         XCTAssertEqual(actualValue?.emailAddress, "")
@@ -73,7 +87,7 @@ class UserTests: XCTestCase {
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.identifier, defaultIdentifier)
         XCTAssertEqual(actualValue?.name, defaultName)
-        XCTAssertEqual(actualValue?.description, "[User][\(defaultIdentifier) - \(defaultFullName)]")
+        XCTAssertEqual(actualValue?.description, "[User][\(defaultIdentifier) - \(defaultName)][\(defaultFullName)]")
         XCTAssertEqual(actualValue?.fullName, defaultFullName)
         XCTAssertEqual(actualValue?.email, defaultEmail)
         XCTAssertEqual(actualValue?.emailAddress, defaultEmailAddress)

--- a/JamfKit/Tests/Session/Requests/BuildingRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/BuildingRequestsTests.swift
@@ -16,13 +16,15 @@ class BuildingRequestsTests: XCTestCase {
 
     let subfolder = "Building/"
     let defaultHost = "http://localhost"
-    let defaultUsername = "username"
-    let defaultPassword = "password"
+    var element: Building!
 
     // MARK: - Lifecycle
 
     override func setUp() {
-        try? SessionManager.instance.configure(for: defaultHost, username: defaultUsername, password: defaultPassword)
+        try? SessionManager.instance.configure(for: defaultHost, username: "username", password: "password")
+
+        let payload = self.payload(for: "building_valid", subfolder: subfolder)!
+        element = Building(json: payload)!
     }
 
     override func tearDown() {
@@ -31,13 +33,84 @@ class BuildingRequestsTests: XCTestCase {
 
     // MARK: - Tests
 
-    func testReturnCreateRequest() {
-        let payload = self.payload(for: "building_valid", subfolder: subfolder)!
-        let element = Building(json: payload)!
+    func testShouldReturnReadAllRequest() {
+        let actualValue = Building.readAll()
 
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/buildings")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnCreateRequest() {
         let actualValue = element.create()
 
         XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
         XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnStaticReadRequestWithIdentifier() {
+        let actualValue = Building.read(identifier: "12345")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(Building.Endpoint)/id/12345")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadRequestWithIdentifier() {
+        let actualValue = element.read()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadRequestWithName() {
+        let actualValue = element.readWithName()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(element.name)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnUpdateRequestWithIdentifier() {
+        let actualValue = element.update()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnUpdateRequestWithName() {
+        let actualValue = element.updateWithName()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(element.name)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnDeleteRequestWithIdentifier() {
+        let actualValue = element.delete()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnDeleteRequestWithName() {
+        let actualValue = element.deleteWithName()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(element.name)")
+        XCTAssertNil(actualValue?.httpBody)
     }
 }

--- a/JamfKit/Tests/Session/Requests/BuildingRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/BuildingRequestsTests.swift
@@ -33,15 +33,6 @@ class BuildingRequestsTests: XCTestCase {
 
     // MARK: - Tests
 
-    func testShouldReturnReadAllRequest() {
-        let actualValue = Building.readAll()
-
-        XCTAssertNotNil(actualValue)
-        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
-        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/buildings")
-        XCTAssertNil(actualValue?.httpBody)
-    }
-
     func testShouldReturnCreateRequest() {
         let actualValue = element.create()
 
@@ -49,6 +40,15 @@ class BuildingRequestsTests: XCTestCase {
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
         XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
         XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadAllRequest() {
+        let actualValue = Building.readAll()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(Building.Endpoint)")
+        XCTAssertNil(actualValue?.httpBody)
     }
 
     func testShouldReturnStaticReadRequestWithIdentifier() {
@@ -94,6 +94,15 @@ class BuildingRequestsTests: XCTestCase {
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
         XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(element.name)")
         XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnStaticDeleteRequestWithIdentifier() {
+        let actualValue = Building.delete(identifier: "12345")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(Building.Endpoint)/id/12345")
+        XCTAssertNil(actualValue?.httpBody)
     }
 
     func testShouldReturnDeleteRequestWithIdentifier() {

--- a/JamfKit/Tests/Session/Requests/BuildingRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/BuildingRequestsTests.swift
@@ -34,7 +34,7 @@ class BuildingRequestsTests: XCTestCase {
     // MARK: - Tests
 
     func testShouldReturnCreateRequest() {
-        let actualValue = element.create()
+        let actualValue = element.createRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
@@ -43,7 +43,7 @@ class BuildingRequestsTests: XCTestCase {
     }
 
     func testShouldReturnReadAllRequest() {
-        let actualValue = Building.readAll()
+        let actualValue = Building.readAllRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -52,7 +52,7 @@ class BuildingRequestsTests: XCTestCase {
     }
 
     func testShouldReturnStaticReadRequestWithIdentifier() {
-        let actualValue = Building.read(identifier: "12345")
+        let actualValue = Building.readRequest(identifier: "12345")
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -61,7 +61,7 @@ class BuildingRequestsTests: XCTestCase {
     }
 
     func testShouldReturnReadRequestWithIdentifier() {
-        let actualValue = element.read()
+        let actualValue = element.readRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -69,8 +69,17 @@ class BuildingRequestsTests: XCTestCase {
         XCTAssertNil(actualValue?.httpBody)
     }
 
+    func testShouldReturnStaticReadRequestWithName() {
+        let actualValue = Building.readRequest(name: "Building")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(Building.Endpoint)/name/Building")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
     func testShouldReturnReadRequestWithName() {
-        let actualValue = element.readWithName()
+        let actualValue = element.readRequestWithName()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -79,7 +88,7 @@ class BuildingRequestsTests: XCTestCase {
     }
 
     func testShouldReturnUpdateRequestWithIdentifier() {
-        let actualValue = element.update()
+        let actualValue = element.updateRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
@@ -88,7 +97,7 @@ class BuildingRequestsTests: XCTestCase {
     }
 
     func testShouldReturnUpdateRequestWithName() {
-        let actualValue = element.updateWithName()
+        let actualValue = element.updateRequestWithName()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
@@ -97,7 +106,7 @@ class BuildingRequestsTests: XCTestCase {
     }
 
     func testShouldReturnStaticDeleteRequestWithIdentifier() {
-        let actualValue = Building.delete(identifier: "12345")
+        let actualValue = Building.deleteRequest(identifier: "12345")
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
@@ -106,7 +115,7 @@ class BuildingRequestsTests: XCTestCase {
     }
 
     func testShouldReturnDeleteRequestWithIdentifier() {
-        let actualValue = element.delete()
+        let actualValue = element.deleteRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
@@ -114,8 +123,17 @@ class BuildingRequestsTests: XCTestCase {
         XCTAssertNil(actualValue?.httpBody)
     }
 
+    func testShouldReturnStaticDeleteRequestWithName() {
+        let actualValue = Building.deleteRequest(name: "12345")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(Building.Endpoint)/name/12345")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
     func testShouldReturnDeleteRequestWithName() {
-        let actualValue = element.deleteWithName()
+        let actualValue = element.deleteRequestWithName()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)

--- a/JamfKit/Tests/Session/Requests/BuildingRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/BuildingRequestsTests.swift
@@ -1,0 +1,43 @@
+//
+//  BuildingRequestsTests.swift
+//  JamfKit
+//
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+//
+
+import XCTest
+
+@testable import JamfKit
+
+class BuildingRequestsTests: XCTestCase {
+
+    // MARK: - Constants
+
+    let subfolder = "Building/"
+    let defaultHost = "http://localhost"
+    let defaultUsername = "username"
+    let defaultPassword = "password"
+
+    // MARK: - Lifecycle
+
+    override func setUp() {
+        try? SessionManager.instance.configure(for: defaultHost, username: defaultUsername, password: defaultPassword)
+    }
+
+    override func tearDown() {
+        SessionManager.instance.clearConfiguration()
+    }
+
+    // MARK: - Tests
+
+    func testReturnCreateRequest() {
+        let payload = self.payload(for: "building_valid", subfolder: subfolder)!
+        let element = Building(json: payload)!
+
+        let actualValue = element.create()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+    }
+}

--- a/JamfKit/Tests/Session/Requests/Computer/ComputerRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/Computer/ComputerRequestsTests.swift
@@ -16,13 +16,15 @@ class ComputerRequestsTests: XCTestCase {
 
     let subfolder = "Computer/"
     let defaultHost = "http://localhost"
-    let defaultUsername = "username"
-    let defaultPassword = "password"
+    var element: Computer!
 
     // MARK: - Lifecycle
 
     override func setUp() {
-        try? SessionManager.instance.configure(for: defaultHost, username: defaultUsername, password: defaultPassword)
+        try? SessionManager.instance.configure(for: defaultHost, username: "username", password: "password")
+
+        let payload = self.payload(for: "computer", subfolder: subfolder)!
+        element = Computer(json: payload)!
     }
 
     override func tearDown() {
@@ -31,13 +33,11 @@ class ComputerRequestsTests: XCTestCase {
 
     // MARK: - Tests
 
-    func testReturnCreateRequest() {
-        let payload = self.payload(for: "computer", subfolder: subfolder)!
-        let element = Computer(json: payload)!
-
-        let actualValue = element.create(with: "id")
+    func testShouldReturnCreateRequest() {
+        let actualValue = element.create()
 
         XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
         XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.general.identifier)")
     }
 }

--- a/JamfKit/Tests/Session/Requests/Computer/ComputerRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/Computer/ComputerRequestsTests.swift
@@ -33,11 +33,165 @@ class ComputerRequestsTests: XCTestCase {
 
     // MARK: - Tests
 
+    func testShouldReturnReadAllRequest() {
+        let actualValue = Computer.readAll()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(Computer.Endpoint)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
     func testShouldReturnCreateRequest() {
         let actualValue = element.create()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
         XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.general.identifier)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnStaticReadRequestWithIdentifier() {
+        let actualValue = Computer.read(identifier: "12345")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(Computer.Endpoint)/id/12345")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadRequestWithIdentifier() {
+        let actualValue = element.read()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.general.identifier)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadRequestWithName() {
+        let actualValue = element.readWithName()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(element.general.name)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadRequestWithUdid() {
+        let actualValue = element.readWithUdid()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/udid/\(element.general.udid)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadRequestWithSerialNumber() {
+        let actualValue = element.readWithSerialNumber()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/serialnumber/\(element.general.serialNumber)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadRequestWithMacAddress() {
+        let actualValue = element.readWithMacAddress()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/macaddress/\(element.general.macAddress)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnUpdateRequestWithIdentifier() {
+        let actualValue = element.update()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.general.identifier)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnUpdateRequestWithName() {
+        let actualValue = element.updateWithName()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(element.general.name)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnUpdateRequestWithUdid() {
+        let actualValue = element.updateWithUdid()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/udid/\(element.general.udid)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnUpdateRequestWithSerialNumber() {
+        let actualValue = element.updateWithSerialNumber()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/serialnumber/\(element.general.serialNumber)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnUpdateRequestWithMacAddress() {
+        let actualValue = element.updateWithMacAddress()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/macaddress/\(element.general.macAddress)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnDeleteRequestWithIdentifier() {
+        let actualValue = element.delete()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.general.identifier)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnDeleteRequestWithName() {
+        let actualValue = element.deleteWithName()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(element.general.name)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnDeleteRequestWithUdid() {
+        let actualValue = element.deleteWithUdid()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/udid/\(element.general.udid)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnDeleteRequestWithSerialNumber() {
+        let actualValue = element.deleteWithSerialNumber()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/serialnumber/\(element.general.serialNumber)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnDeleteRequestWithMacAddress() {
+        let actualValue = element.deleteWithMacAddress()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/macaddress/\(element.general.macAddress)")
+        XCTAssertNil(actualValue?.httpBody)
     }
 }

--- a/JamfKit/Tests/Session/Requests/Computer/ComputerRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/Computer/ComputerRequestsTests.swift
@@ -1,0 +1,43 @@
+//
+//  ComputerRequestsTests.swift
+//  JamfKit
+//
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+//
+
+import XCTest
+
+@testable import JamfKit
+
+class ComputerRequestsTests: XCTestCase {
+
+    // MARK: - Constants
+
+    let subfolder = "Computer/"
+    let defaultHost = "http://localhost"
+    let defaultUsername = "username"
+    let defaultPassword = "password"
+
+    // MARK: - Lifecycle
+
+    override func setUp() {
+        try? SessionManager.instance.configure(for: defaultHost, username: defaultUsername, password: defaultPassword)
+    }
+
+    override func tearDown() {
+        SessionManager.instance.clearConfiguration()
+    }
+
+    // MARK: - Tests
+
+    func testReturnCreateRequest() {
+        let payload = self.payload(for: "computer", subfolder: subfolder)!
+        let element = Computer(json: payload)!
+
+        let actualValue = element.create(with: "id")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.general.identifier)")
+    }
+}

--- a/JamfKit/Tests/Session/Requests/Computer/ComputerRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/Computer/ComputerRequestsTests.swift
@@ -34,7 +34,7 @@ class ComputerRequestsTests: XCTestCase {
     // MARK: - Tests
 
     func testShouldReturnReadAllRequest() {
-        let actualValue = Computer.readAll()
+        let actualValue = Computer.readAllRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -43,7 +43,7 @@ class ComputerRequestsTests: XCTestCase {
     }
 
     func testShouldReturnCreateRequest() {
-        let actualValue = element.create()
+        let actualValue = element.createRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
@@ -52,7 +52,7 @@ class ComputerRequestsTests: XCTestCase {
     }
 
     func testShouldReturnStaticReadRequestWithIdentifier() {
-        let actualValue = Computer.read(identifier: "12345")
+        let actualValue = Computer.readRequest(identifier: "12345")
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -61,7 +61,7 @@ class ComputerRequestsTests: XCTestCase {
     }
 
     func testShouldReturnReadRequestWithIdentifier() {
-        let actualValue = element.read()
+        let actualValue = element.readRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -70,7 +70,7 @@ class ComputerRequestsTests: XCTestCase {
     }
 
     func testShouldReturnReadRequestWithName() {
-        let actualValue = element.readWithName()
+        let actualValue = element.readRequestWithName()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -79,7 +79,7 @@ class ComputerRequestsTests: XCTestCase {
     }
 
     func testShouldReturnReadRequestWithUdid() {
-        let actualValue = element.readWithUdid()
+        let actualValue = element.readRequestWithUdid()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -88,7 +88,7 @@ class ComputerRequestsTests: XCTestCase {
     }
 
     func testShouldReturnReadRequestWithSerialNumber() {
-        let actualValue = element.readWithSerialNumber()
+        let actualValue = element.readRequestWithSerialNumber()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -97,7 +97,7 @@ class ComputerRequestsTests: XCTestCase {
     }
 
     func testShouldReturnReadRequestWithMacAddress() {
-        let actualValue = element.readWithMacAddress()
+        let actualValue = element.readRequestWithMacAddress()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -106,7 +106,7 @@ class ComputerRequestsTests: XCTestCase {
     }
 
     func testShouldReturnUpdateRequestWithIdentifier() {
-        let actualValue = element.update()
+        let actualValue = element.updateRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
@@ -115,7 +115,7 @@ class ComputerRequestsTests: XCTestCase {
     }
 
     func testShouldReturnUpdateRequestWithName() {
-        let actualValue = element.updateWithName()
+        let actualValue = element.updateRequestWithName()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
@@ -124,7 +124,7 @@ class ComputerRequestsTests: XCTestCase {
     }
 
     func testShouldReturnUpdateRequestWithUdid() {
-        let actualValue = element.updateWithUdid()
+        let actualValue = element.updateRequestWithUdid()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
@@ -133,7 +133,7 @@ class ComputerRequestsTests: XCTestCase {
     }
 
     func testShouldReturnUpdateRequestWithSerialNumber() {
-        let actualValue = element.updateWithSerialNumber()
+        let actualValue = element.updateRequestWithSerialNumber()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
@@ -142,7 +142,7 @@ class ComputerRequestsTests: XCTestCase {
     }
 
     func testShouldReturnUpdateRequestWithMacAddress() {
-        let actualValue = element.updateWithMacAddress()
+        let actualValue = element.updateRequestWithMacAddress()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
@@ -151,7 +151,7 @@ class ComputerRequestsTests: XCTestCase {
     }
 
     func testShouldReturnDeleteRequestWithIdentifier() {
-        let actualValue = element.delete()
+        let actualValue = element.deleteRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
@@ -160,7 +160,7 @@ class ComputerRequestsTests: XCTestCase {
     }
 
     func testShouldReturnDeleteRequestWithName() {
-        let actualValue = element.deleteWithName()
+        let actualValue = element.deleteRequestWithName()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
@@ -169,7 +169,7 @@ class ComputerRequestsTests: XCTestCase {
     }
 
     func testShouldReturnDeleteRequestWithUdid() {
-        let actualValue = element.deleteWithUdid()
+        let actualValue = element.deleteRequestWithUdid()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
@@ -178,7 +178,7 @@ class ComputerRequestsTests: XCTestCase {
     }
 
     func testShouldReturnDeleteRequestWithSerialNumber() {
-        let actualValue = element.deleteWithSerialNumber()
+        let actualValue = element.deleteRequestWithSerialNumber()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
@@ -187,7 +187,7 @@ class ComputerRequestsTests: XCTestCase {
     }
 
     func testShouldReturnDeleteRequestWithMacAddress() {
-        let actualValue = element.deleteWithMacAddress()
+        let actualValue = element.deleteRequestWithMacAddress()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)

--- a/JamfKit/Tests/Session/Requests/ComputerCommand/ComputerCommandRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/ComputerCommand/ComputerCommandRequestsTests.swift
@@ -59,7 +59,7 @@ class ComputerCommandRequestsTests: XCTestCase {
 
     func testShouldNotReturnReadRequestWithIdentifier() {
         let actualValue = element.read()
-        
+
         XCTAssertNil(actualValue)
     }
 }

--- a/JamfKit/Tests/Session/Requests/ComputerCommand/ComputerCommandRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/ComputerCommand/ComputerCommandRequestsTests.swift
@@ -33,11 +33,33 @@ class ComputerCommandRequestsTests: XCTestCase {
 
     // MARK: - Tests
 
+    func testShouldReturnReadAllRequest() {
+        let actualValue = ComputerCommand.readAll()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(ComputerCommand.Endpoint)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
     func testShouldReturnCreateRequest() {
         let actualValue = element.create()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
         XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/command/\(element.general.command)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldNotReturnStaticReadRequestWithIdentifier() {
+        let actualValue = ComputerCommand.read(identifier: "12345")
+
+        XCTAssertNil(actualValue)
+    }
+
+    func testShouldNotReturnReadRequestWithIdentifier() {
+        let actualValue = element.read()
+        
+        XCTAssertNil(actualValue)
     }
 }

--- a/JamfKit/Tests/Session/Requests/ComputerCommand/ComputerCommandRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/ComputerCommand/ComputerCommandRequestsTests.swift
@@ -1,0 +1,43 @@
+//
+//  ComputerCommandRequestsTests.swift
+//  JamfKit
+//
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+//
+
+import XCTest
+
+@testable import JamfKit
+
+class ComputerCommandRequestsTests: XCTestCase {
+
+    // MARK: - Constants
+
+    let subfolder = "ComputerCommand/"
+    let defaultHost = "http://localhost"
+    let defaultUsername = "username"
+    let defaultPassword = "password"
+
+    // MARK: - Lifecycle
+
+    override func setUp() {
+        try? SessionManager.instance.configure(for: defaultHost, username: defaultUsername, password: defaultPassword)
+    }
+
+    override func tearDown() {
+        SessionManager.instance.clearConfiguration()
+    }
+
+    // MARK: - Tests
+
+    func testReturnCreateRequest() {
+        let payload = self.payload(for: "computer_command", subfolder: subfolder)!
+        let element = ComputerCommand(json: payload)!
+
+        let actualValue = element.create(with: ComputerCommandGeneral.CommandKey)
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/command/\(element.general.command)")
+    }
+}

--- a/JamfKit/Tests/Session/Requests/ComputerCommand/ComputerCommandRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/ComputerCommand/ComputerCommandRequestsTests.swift
@@ -16,13 +16,15 @@ class ComputerCommandRequestsTests: XCTestCase {
 
     let subfolder = "ComputerCommand/"
     let defaultHost = "http://localhost"
-    let defaultUsername = "username"
-    let defaultPassword = "password"
+    var element: ComputerCommand!
 
     // MARK: - Lifecycle
 
     override func setUp() {
-        try? SessionManager.instance.configure(for: defaultHost, username: defaultUsername, password: defaultPassword)
+        try? SessionManager.instance.configure(for: defaultHost, username: "username", password: "password")
+
+        let payload = self.payload(for: "computer_command", subfolder: subfolder)!
+        element = ComputerCommand(json: payload)!
     }
 
     override func tearDown() {
@@ -31,13 +33,11 @@ class ComputerCommandRequestsTests: XCTestCase {
 
     // MARK: - Tests
 
-    func testReturnCreateRequest() {
-        let payload = self.payload(for: "computer_command", subfolder: subfolder)!
-        let element = ComputerCommand(json: payload)!
-
-        let actualValue = element.create(with: ComputerCommandGeneral.CommandKey)
+    func testShouldReturnCreateRequest() {
+        let actualValue = element.create()
 
         XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
         XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/command/\(element.general.command)")
     }
 }

--- a/JamfKit/Tests/Session/Requests/ComputerCommand/ComputerCommandRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/ComputerCommand/ComputerCommandRequestsTests.swift
@@ -34,7 +34,7 @@ class ComputerCommandRequestsTests: XCTestCase {
     // MARK: - Tests
 
     func testShouldReturnReadAllRequest() {
-        let actualValue = ComputerCommand.readAll()
+        let actualValue = ComputerCommand.readAllRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -43,7 +43,7 @@ class ComputerCommandRequestsTests: XCTestCase {
     }
 
     func testShouldReturnCreateRequest() {
-        let actualValue = element.create()
+        let actualValue = element.createRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
@@ -52,13 +52,13 @@ class ComputerCommandRequestsTests: XCTestCase {
     }
 
     func testShouldNotReturnStaticReadRequestWithIdentifier() {
-        let actualValue = ComputerCommand.read(identifier: "12345")
+        let actualValue = ComputerCommand.readRequest(identifier: "12345")
 
         XCTAssertNil(actualValue)
     }
 
     func testShouldNotReturnReadRequestWithIdentifier() {
-        let actualValue = element.read()
+        let actualValue = element.readRequest()
 
         XCTAssertNil(actualValue)
     }

--- a/JamfKit/Tests/Session/Requests/ComputerConfiguration/ComputerConfigurationRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/ComputerConfiguration/ComputerConfigurationRequestsTests.swift
@@ -1,0 +1,43 @@
+//
+//  ComputerConfigurationRequestsTests.swift
+//  JamfKit
+//
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+//
+
+import XCTest
+
+@testable import JamfKit
+
+class ComputerConfigurationRequestsTests: XCTestCase {
+
+    // MARK: - Constants
+
+    let subfolder = "ComputerConfiguration/"
+    let defaultHost = "http://localhost"
+    let defaultUsername = "username"
+    let defaultPassword = "password"
+
+    // MARK: - Lifecycle
+
+    override func setUp() {
+        try? SessionManager.instance.configure(for: defaultHost, username: defaultUsername, password: defaultPassword)
+    }
+
+    override func tearDown() {
+        SessionManager.instance.clearConfiguration()
+    }
+
+    // MARK: - Tests
+
+    func testReturnCreateRequest() {
+        let payload = self.payload(for: "computer_configuration", subfolder: subfolder)!
+        let element = ComputerConfiguration(json: payload)!
+
+        let actualValue = element.create(with: "id")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.general.identifier)")
+    }
+}

--- a/JamfKit/Tests/Session/Requests/ComputerConfiguration/ComputerConfigurationRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/ComputerConfiguration/ComputerConfigurationRequestsTests.swift
@@ -34,7 +34,7 @@ class ComputerConfigurationRequestsTests: XCTestCase {
     // MARK: - Tests
 
     func testShouldReturnCreateRequest() {
-        let actualValue = element.create()
+        let actualValue = element.createRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
@@ -43,7 +43,7 @@ class ComputerConfigurationRequestsTests: XCTestCase {
     }
 
     func testShouldReturnReadAllRequest() {
-        let actualValue = ComputerConfiguration.readAll()
+        let actualValue = ComputerConfiguration.readAllRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -52,7 +52,7 @@ class ComputerConfigurationRequestsTests: XCTestCase {
     }
 
     func testShouldReturnStaticReadRequestWithIdentifier() {
-        let actualValue = ComputerConfiguration.read(identifier: "12345")
+        let actualValue = ComputerConfiguration.readRequest(identifier: "12345")
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -61,7 +61,7 @@ class ComputerConfigurationRequestsTests: XCTestCase {
     }
 
     func testShouldReturnReadRequestWithIdentifier() {
-        let actualValue = element.read()
+        let actualValue = element.readRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -70,7 +70,7 @@ class ComputerConfigurationRequestsTests: XCTestCase {
     }
 
     func testShouldReturnReadRequestWithName() {
-        let actualValue = element.readWithName()
+        let actualValue = element.readRequestWithName()
         let encodedName = element.general.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
 
         XCTAssertNotNil(actualValue)
@@ -80,7 +80,7 @@ class ComputerConfigurationRequestsTests: XCTestCase {
     }
 
     func testShouldReturnUpdateRequestWithIdentifier() {
-        let actualValue = element.update()
+        let actualValue = element.updateRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
@@ -89,7 +89,7 @@ class ComputerConfigurationRequestsTests: XCTestCase {
     }
 
     func testShouldReturnUpdateRequestWithName() {
-        let actualValue = element.updateWithName()
+        let actualValue = element.updateRequestWithName()
         let encodedName = element.general.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
 
         XCTAssertNotNil(actualValue)
@@ -99,7 +99,7 @@ class ComputerConfigurationRequestsTests: XCTestCase {
     }
 
     func testShouldReturnDeleteRequestWithIdentifier() {
-        let actualValue = element.delete()
+        let actualValue = element.deleteRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
@@ -108,7 +108,7 @@ class ComputerConfigurationRequestsTests: XCTestCase {
     }
 
     func testShouldReturnDeleteRequestWithName() {
-        let actualValue = element.deleteWithName()
+        let actualValue = element.deleteRequestWithName()
         let encodedName = element.general.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
 
         XCTAssertNotNil(actualValue)

--- a/JamfKit/Tests/Session/Requests/ComputerConfiguration/ComputerConfigurationRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/ComputerConfiguration/ComputerConfigurationRequestsTests.swift
@@ -16,13 +16,15 @@ class ComputerConfigurationRequestsTests: XCTestCase {
 
     let subfolder = "ComputerConfiguration/"
     let defaultHost = "http://localhost"
-    let defaultUsername = "username"
-    let defaultPassword = "password"
+    var element: ComputerConfiguration!
 
     // MARK: - Lifecycle
 
     override func setUp() {
-        try? SessionManager.instance.configure(for: defaultHost, username: defaultUsername, password: defaultPassword)
+        try? SessionManager.instance.configure(for: defaultHost, username: "username", password: "password")
+
+        let payload = self.payload(for: "computer_configuration", subfolder: subfolder)!
+        element = ComputerConfiguration(json: payload)!
     }
 
     override func tearDown() {
@@ -31,13 +33,11 @@ class ComputerConfigurationRequestsTests: XCTestCase {
 
     // MARK: - Tests
 
-    func testReturnCreateRequest() {
-        let payload = self.payload(for: "computer_configuration", subfolder: subfolder)!
-        let element = ComputerConfiguration(json: payload)!
-
-        let actualValue = element.create(with: "id")
+    func testShouldReturnCreateRequest() {
+        let actualValue = element.create()
 
         XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
         XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.general.identifier)")
     }
 }

--- a/JamfKit/Tests/Session/Requests/ComputerGroup/ComputerGroupRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/ComputerGroup/ComputerGroupRequestsTests.swift
@@ -34,7 +34,7 @@ class ComputerGroupRequestsTests: XCTestCase {
     // MARK: - Tests
 
     func testShouldReturnCreateRequest() {
-        let actualValue = element.create()
+        let actualValue = element.createRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
@@ -42,7 +42,7 @@ class ComputerGroupRequestsTests: XCTestCase {
     }
 
     func testShouldReturnReadAllRequest() {
-        let actualValue = ComputerGroup.readAll()
+        let actualValue = ComputerGroup.readAllRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -51,7 +51,7 @@ class ComputerGroupRequestsTests: XCTestCase {
     }
 
     func testShouldReturnStaticReadRequestWithIdentifier() {
-        let actualValue = ComputerGroup.read(identifier: "12345")
+        let actualValue = ComputerGroup.readRequest(identifier: "12345")
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -60,7 +60,7 @@ class ComputerGroupRequestsTests: XCTestCase {
     }
 
     func testShouldReturnReadRequestWithIdentifier() {
-        let actualValue = element.read()
+        let actualValue = element.readRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -68,8 +68,17 @@ class ComputerGroupRequestsTests: XCTestCase {
         XCTAssertNil(actualValue?.httpBody)
     }
 
+    func testShouldReturnStaticReadRequestWithName() {
+        let actualValue = ComputerGroup.readRequest(name: "Computer Group")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(ComputerGroup.Endpoint)/name/Computer%20Group")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
     func testShouldReturnReadRequestWithName() {
-        let actualValue = element.readWithName()
+        let actualValue = element.readRequestWithName()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -78,7 +87,7 @@ class ComputerGroupRequestsTests: XCTestCase {
     }
 
     func testShouldReturnUpdateRequestWithIdentifier() {
-        let actualValue = element.update()
+        let actualValue = element.updateRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
@@ -87,7 +96,7 @@ class ComputerGroupRequestsTests: XCTestCase {
     }
 
     func testShouldReturnUpdateRequestWithName() {
-        let actualValue = element.updateWithName()
+        let actualValue = element.updateRequestWithName()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
@@ -96,7 +105,7 @@ class ComputerGroupRequestsTests: XCTestCase {
     }
 
     func testShouldReturnStaticDeleteRequestWithIdentifier() {
-        let actualValue = ComputerGroup.delete(identifier: "12345")
+        let actualValue = ComputerGroup.deleteRequest(identifier: "12345")
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
@@ -105,7 +114,7 @@ class ComputerGroupRequestsTests: XCTestCase {
     }
 
     func testShouldReturnDeleteRequestWithIdentifier() {
-        let actualValue = element.delete()
+        let actualValue = element.deleteRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
@@ -113,8 +122,17 @@ class ComputerGroupRequestsTests: XCTestCase {
         XCTAssertNil(actualValue?.httpBody)
     }
 
+    func testShouldReturnStaticDeleteRequestWithName() {
+        let actualValue = ComputerGroup.deleteRequest(name: "12345")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(ComputerGroup.Endpoint)/name/12345")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
     func testShouldReturnDeleteRequestWithName() {
-        let actualValue = element.deleteWithName()
+        let actualValue = element.deleteRequestWithName()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)

--- a/JamfKit/Tests/Session/Requests/ComputerGroup/ComputerGroupRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/ComputerGroup/ComputerGroupRequestsTests.swift
@@ -1,0 +1,43 @@
+//
+//  ComputerGroupRequestsTests.swift
+//  JamfKit
+//
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+//
+
+import XCTest
+
+@testable import JamfKit
+
+class ComputerGroupRequestsTests: XCTestCase {
+
+    // MARK: - Constants
+
+    let subfolder = "ComputerGroup/"
+    let defaultHost = "http://localhost"
+    let defaultUsername = "username"
+    let defaultPassword = "password"
+
+    // MARK: - Lifecycle
+
+    override func setUp() {
+        try? SessionManager.instance.configure(for: defaultHost, username: defaultUsername, password: defaultPassword)
+    }
+
+    override func tearDown() {
+        SessionManager.instance.clearConfiguration()
+    }
+
+    // MARK: - Tests
+
+    func testReturnCreateRequest() {
+        let payload = self.payload(for: "computer_group_valid", subfolder: subfolder)!
+        let element = ComputerGroup(json: payload)!
+
+        let actualValue = element.create()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+    }
+}

--- a/JamfKit/Tests/Session/Requests/ComputerGroup/ComputerGroupRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/ComputerGroup/ComputerGroupRequestsTests.swift
@@ -16,13 +16,15 @@ class ComputerGroupRequestsTests: XCTestCase {
 
     let subfolder = "ComputerGroup/"
     let defaultHost = "http://localhost"
-    let defaultUsername = "username"
-    let defaultPassword = "password"
+    var element: ComputerGroup!
 
     // MARK: - Lifecycle
 
     override func setUp() {
-        try? SessionManager.instance.configure(for: defaultHost, username: defaultUsername, password: defaultPassword)
+        try? SessionManager.instance.configure(for: defaultHost, username: "username", password: "password")
+
+        let payload = self.payload(for: "computer_group_valid", subfolder: subfolder)!
+        element = ComputerGroup(json: payload)!
     }
 
     override func tearDown() {
@@ -31,13 +33,11 @@ class ComputerGroupRequestsTests: XCTestCase {
 
     // MARK: - Tests
 
-    func testReturnCreateRequest() {
-        let payload = self.payload(for: "computer_group_valid", subfolder: subfolder)!
-        let element = ComputerGroup(json: payload)!
-
+    func testShouldReturnCreateRequest() {
         let actualValue = element.create()
 
         XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
         XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
     }
 }

--- a/JamfKit/Tests/Session/Requests/ComputerGroup/ComputerGroupRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/ComputerGroup/ComputerGroupRequestsTests.swift
@@ -40,4 +40,85 @@ class ComputerGroupRequestsTests: XCTestCase {
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
         XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
     }
+
+    func testShouldReturnReadAllRequest() {
+        let actualValue = ComputerGroup.readAll()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(ComputerGroup.Endpoint)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnStaticReadRequestWithIdentifier() {
+        let actualValue = ComputerGroup.read(identifier: "12345")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(ComputerGroup.Endpoint)/id/12345")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadRequestWithIdentifier() {
+        let actualValue = element.read()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadRequestWithName() {
+        let actualValue = element.readWithName()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(element.name)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnUpdateRequestWithIdentifier() {
+        let actualValue = element.update()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnUpdateRequestWithName() {
+        let actualValue = element.updateWithName()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(element.name)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnStaticDeleteRequestWithIdentifier() {
+        let actualValue = ComputerGroup.delete(identifier: "12345")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(ComputerGroup.Endpoint)/id/12345")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnDeleteRequestWithIdentifier() {
+        let actualValue = element.delete()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnDeleteRequestWithName() {
+        let actualValue = element.deleteWithName()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(element.name)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
 }

--- a/JamfKit/Tests/Session/Requests/DepartmentRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/DepartmentRequestsTests.swift
@@ -16,13 +16,15 @@ class DepartmentRequestsTests: XCTestCase {
 
     let subfolder = "Department/"
     let defaultHost = "http://localhost"
-    let defaultUsername = "username"
-    let defaultPassword = "password"
+    var element: Department!
 
     // MARK: - Lifecycle
 
     override func setUp() {
-        try? SessionManager.instance.configure(for: defaultHost, username: defaultUsername, password: defaultPassword)
+        try? SessionManager.instance.configure(for: defaultHost, username: "username", password: "password")
+
+        let payload = self.payload(for: "department_valid", subfolder: subfolder)!
+        element = Department(json: payload)!
     }
 
     override func tearDown() {
@@ -31,13 +33,11 @@ class DepartmentRequestsTests: XCTestCase {
 
     // MARK: - Tests
 
-    func testReturnCreateRequest() {
-        let payload = self.payload(for: "department_valid", subfolder: subfolder)!
-        let element = Department(json: payload)!
-
+    func testShouldReturnCreateRequest() {
         let actualValue = element.create()
 
         XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
         XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
     }
 }

--- a/JamfKit/Tests/Session/Requests/DepartmentRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/DepartmentRequestsTests.swift
@@ -39,5 +39,87 @@ class DepartmentRequestsTests: XCTestCase {
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
         XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadAllRequest() {
+        let actualValue = Department.readAll()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(Department.Endpoint)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnStaticReadRequestWithIdentifier() {
+        let actualValue = Department.read(identifier: "12345")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(Department.Endpoint)/id/12345")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadRequestWithIdentifier() {
+        let actualValue = element.read()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadRequestWithName() {
+        let actualValue = element.readWithName()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(element.name)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnUpdateRequestWithIdentifier() {
+        let actualValue = element.update()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnUpdateRequestWithName() {
+        let actualValue = element.updateWithName()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(element.name)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnStaticDeleteRequestWithIdentifier() {
+        let actualValue = Department.delete(identifier: "12345")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(Department.Endpoint)/id/12345")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnDeleteRequestWithIdentifier() {
+        let actualValue = element.delete()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnDeleteRequestWithName() {
+        let actualValue = element.deleteWithName()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(element.name)")
+        XCTAssertNil(actualValue?.httpBody)
     }
 }

--- a/JamfKit/Tests/Session/Requests/DepartmentRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/DepartmentRequestsTests.swift
@@ -1,0 +1,43 @@
+//
+//  DepartmentRequestsTests.swift
+//  JamfKit
+//
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+//
+
+import XCTest
+
+@testable import JamfKit
+
+class DepartmentRequestsTests: XCTestCase {
+
+    // MARK: - Constants
+
+    let subfolder = "Department/"
+    let defaultHost = "http://localhost"
+    let defaultUsername = "username"
+    let defaultPassword = "password"
+
+    // MARK: - Lifecycle
+
+    override func setUp() {
+        try? SessionManager.instance.configure(for: defaultHost, username: defaultUsername, password: defaultPassword)
+    }
+
+    override func tearDown() {
+        SessionManager.instance.clearConfiguration()
+    }
+
+    // MARK: - Tests
+
+    func testReturnCreateRequest() {
+        let payload = self.payload(for: "department_valid", subfolder: subfolder)!
+        let element = Department(json: payload)!
+
+        let actualValue = element.create()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+    }
+}

--- a/JamfKit/Tests/Session/Requests/DepartmentRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/DepartmentRequestsTests.swift
@@ -34,7 +34,7 @@ class DepartmentRequestsTests: XCTestCase {
     // MARK: - Tests
 
     func testShouldReturnCreateRequest() {
-        let actualValue = element.create()
+        let actualValue = element.createRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
@@ -43,7 +43,7 @@ class DepartmentRequestsTests: XCTestCase {
     }
 
     func testShouldReturnReadAllRequest() {
-        let actualValue = Department.readAll()
+        let actualValue = Department.readAllRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -52,7 +52,7 @@ class DepartmentRequestsTests: XCTestCase {
     }
 
     func testShouldReturnStaticReadRequestWithIdentifier() {
-        let actualValue = Department.read(identifier: "12345")
+        let actualValue = Department.readRequest(identifier: "12345")
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -61,7 +61,7 @@ class DepartmentRequestsTests: XCTestCase {
     }
 
     func testShouldReturnReadRequestWithIdentifier() {
-        let actualValue = element.read()
+        let actualValue = element.readRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -69,8 +69,17 @@ class DepartmentRequestsTests: XCTestCase {
         XCTAssertNil(actualValue?.httpBody)
     }
 
+    func testShouldReturnStaticReadRequestWithName() {
+        let actualValue = Department.readRequest(name: "Department")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(Department.Endpoint)/name/Department")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
     func testShouldReturnReadRequestWithName() {
-        let actualValue = element.readWithName()
+        let actualValue = element.readRequestWithName()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -79,7 +88,7 @@ class DepartmentRequestsTests: XCTestCase {
     }
 
     func testShouldReturnUpdateRequestWithIdentifier() {
-        let actualValue = element.update()
+        let actualValue = element.updateRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
@@ -88,7 +97,7 @@ class DepartmentRequestsTests: XCTestCase {
     }
 
     func testShouldReturnUpdateRequestWithName() {
-        let actualValue = element.updateWithName()
+        let actualValue = element.updateRequestWithName()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
@@ -97,7 +106,7 @@ class DepartmentRequestsTests: XCTestCase {
     }
 
     func testShouldReturnStaticDeleteRequestWithIdentifier() {
-        let actualValue = Department.delete(identifier: "12345")
+        let actualValue = Department.deleteRequest(identifier: "12345")
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
@@ -106,7 +115,7 @@ class DepartmentRequestsTests: XCTestCase {
     }
 
     func testShouldReturnDeleteRequestWithIdentifier() {
-        let actualValue = element.delete()
+        let actualValue = element.deleteRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
@@ -114,8 +123,17 @@ class DepartmentRequestsTests: XCTestCase {
         XCTAssertNil(actualValue?.httpBody)
     }
 
+    func testShouldReturnStaticDeleteRequestWithName() {
+        let actualValue = Department.deleteRequest(name: "12345")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(Department.Endpoint)/name/12345")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
     func testShouldReturnDeleteRequestWithName() {
-        let actualValue = element.deleteWithName()
+        let actualValue = element.deleteRequestWithName()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)

--- a/JamfKit/Tests/Session/Requests/DirectoryBindingRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/DirectoryBindingRequestsTests.swift
@@ -1,0 +1,43 @@
+//
+//  DirectoryBindingRequestsTests.swift
+//  JamfKit
+//
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+//
+
+import XCTest
+
+@testable import JamfKit
+
+class DirectoryBindingRequestsTests: XCTestCase {
+
+    // MARK: - Constants
+
+    let subfolder = "DirectoryBinding/"
+    let defaultHost = "http://localhost"
+    let defaultUsername = "username"
+    let defaultPassword = "password"
+
+    // MARK: - Lifecycle
+
+    override func setUp() {
+        try? SessionManager.instance.configure(for: defaultHost, username: defaultUsername, password: defaultPassword)
+    }
+
+    override func tearDown() {
+        SessionManager.instance.clearConfiguration()
+    }
+
+    // MARK: - Tests
+
+    func testReturnCreateRequest() {
+        let payload = self.payload(for: "directory_binding_valid", subfolder: subfolder)!
+        let element = DirectoryBinding(json: payload)!
+
+        let actualValue = element.create()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+    }
+}

--- a/JamfKit/Tests/Session/Requests/DirectoryBindingRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/DirectoryBindingRequestsTests.swift
@@ -34,7 +34,7 @@ class DirectoryBindingRequestsTests: XCTestCase {
     // MARK: - Tests
 
     func testShouldReturnCreateRequest() {
-        let actualValue = element.create()
+        let actualValue = element.createRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
@@ -43,7 +43,7 @@ class DirectoryBindingRequestsTests: XCTestCase {
     }
 
     func testShouldReturnReadAllRequest() {
-        let actualValue = DirectoryBinding.readAll()
+        let actualValue = DirectoryBinding.readAllRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -52,7 +52,7 @@ class DirectoryBindingRequestsTests: XCTestCase {
     }
 
     func testShouldReturnStaticReadRequestWithIdentifier() {
-        let actualValue = DirectoryBinding.read(identifier: "12345")
+        let actualValue = DirectoryBinding.readRequest(identifier: "12345")
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -61,7 +61,7 @@ class DirectoryBindingRequestsTests: XCTestCase {
     }
 
     func testShouldReturnReadRequestWithIdentifier() {
-        let actualValue = element.read()
+        let actualValue = element.readRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -69,8 +69,17 @@ class DirectoryBindingRequestsTests: XCTestCase {
         XCTAssertNil(actualValue?.httpBody)
     }
 
+    func testShouldReturnStaticReadRequestWithName() {
+        let actualValue = DirectoryBinding.readRequest(name: "Directory Binding")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(DirectoryBinding.Endpoint)/name/Directory%20Binding")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
     func testShouldReturnReadRequestWithName() {
-        let actualValue = element.readWithName()
+        let actualValue = element.readRequestWithName()
         let encodedName = element.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
 
         XCTAssertNotNil(actualValue)
@@ -80,7 +89,7 @@ class DirectoryBindingRequestsTests: XCTestCase {
     }
 
     func testShouldReturnUpdateRequestWithIdentifier() {
-        let actualValue = element.update()
+        let actualValue = element.updateRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
@@ -89,7 +98,7 @@ class DirectoryBindingRequestsTests: XCTestCase {
     }
 
     func testShouldReturnUpdateRequestWithName() {
-        let actualValue = element.updateWithName()
+        let actualValue = element.updateRequestWithName()
         let encodedName = element.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
 
         XCTAssertNotNil(actualValue)
@@ -99,7 +108,7 @@ class DirectoryBindingRequestsTests: XCTestCase {
     }
 
     func testShouldReturnStaticDeleteRequestWithIdentifier() {
-        let actualValue = DirectoryBinding.delete(identifier: "12345")
+        let actualValue = DirectoryBinding.deleteRequest(identifier: "12345")
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
@@ -108,7 +117,7 @@ class DirectoryBindingRequestsTests: XCTestCase {
     }
 
     func testShouldReturnDeleteRequestWithIdentifier() {
-        let actualValue = element.delete()
+        let actualValue = element.deleteRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
@@ -116,8 +125,17 @@ class DirectoryBindingRequestsTests: XCTestCase {
         XCTAssertNil(actualValue?.httpBody)
     }
 
+    func testShouldReturnStaticDeleteRequestWithName() {
+        let actualValue = DirectoryBinding.deleteRequest(name: "12345")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(DirectoryBinding.Endpoint)/name/12345")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
     func testShouldReturnDeleteRequestWithName() {
-        let actualValue = element.deleteWithName()
+        let actualValue = element.deleteRequestWithName()
         let encodedName = element.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
 
         XCTAssertNotNil(actualValue)

--- a/JamfKit/Tests/Session/Requests/DirectoryBindingRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/DirectoryBindingRequestsTests.swift
@@ -39,5 +39,90 @@ class DirectoryBindingRequestsTests: XCTestCase {
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
         XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadAllRequest() {
+        let actualValue = DirectoryBinding.readAll()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(DirectoryBinding.Endpoint)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnStaticReadRequestWithIdentifier() {
+        let actualValue = DirectoryBinding.read(identifier: "12345")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(DirectoryBinding.Endpoint)/id/12345")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadRequestWithIdentifier() {
+        let actualValue = element.read()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadRequestWithName() {
+        let actualValue = element.readWithName()
+        let encodedName = element.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(encodedName)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnUpdateRequestWithIdentifier() {
+        let actualValue = element.update()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnUpdateRequestWithName() {
+        let actualValue = element.updateWithName()
+        let encodedName = element.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(encodedName)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnStaticDeleteRequestWithIdentifier() {
+        let actualValue = DirectoryBinding.delete(identifier: "12345")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(DirectoryBinding.Endpoint)/id/12345")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnDeleteRequestWithIdentifier() {
+        let actualValue = element.delete()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnDeleteRequestWithName() {
+        let actualValue = element.deleteWithName()
+        let encodedName = element.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(encodedName)")
+        XCTAssertNil(actualValue?.httpBody)
     }
 }

--- a/JamfKit/Tests/Session/Requests/DirectoryBindingRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/DirectoryBindingRequestsTests.swift
@@ -16,13 +16,15 @@ class DirectoryBindingRequestsTests: XCTestCase {
 
     let subfolder = "DirectoryBinding/"
     let defaultHost = "http://localhost"
-    let defaultUsername = "username"
-    let defaultPassword = "password"
+    var element: DirectoryBinding!
 
     // MARK: - Lifecycle
 
     override func setUp() {
-        try? SessionManager.instance.configure(for: defaultHost, username: defaultUsername, password: defaultPassword)
+        try? SessionManager.instance.configure(for: defaultHost, username: "username", password: "password")
+
+        let payload = self.payload(for: "directory_binding_valid", subfolder: subfolder)!
+        element = DirectoryBinding(json: payload)!
     }
 
     override func tearDown() {
@@ -31,13 +33,11 @@ class DirectoryBindingRequestsTests: XCTestCase {
 
     // MARK: - Tests
 
-    func testReturnCreateRequest() {
-        let payload = self.payload(for: "directory_binding_valid", subfolder: subfolder)!
-        let element = DirectoryBinding(json: payload)!
-
+    func testShouldReturnCreateRequest() {
         let actualValue = element.create()
 
         XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
         XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
     }
 }

--- a/JamfKit/Tests/Session/Requests/MobileDevice/MobileDeviceRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/MobileDevice/MobileDeviceRequestsTests.swift
@@ -16,13 +16,15 @@ class MobileDeviceRequestsTests: XCTestCase {
 
     let subfolder = "MobileDevice/"
     let defaultHost = "http://localhost"
-    let defaultUsername = "username"
-    let defaultPassword = "password"
+    var element: MobileDevice!
 
     // MARK: - Lifecycle
 
     override func setUp() {
-        try? SessionManager.instance.configure(for: defaultHost, username: defaultUsername, password: defaultPassword)
+        try? SessionManager.instance.configure(for: defaultHost, username: "username", password: "password")
+
+        let payload = self.payload(for: "mobile_device", subfolder: subfolder)!
+        element = MobileDevice(json: payload)!
     }
 
     override func tearDown() {
@@ -31,13 +33,11 @@ class MobileDeviceRequestsTests: XCTestCase {
 
     // MARK: - Tests
 
-    func testReturnCreateRequest() {
-        let payload = self.payload(for: "mobile_device", subfolder: subfolder)!
-        let element = MobileDevice(json: payload)!
-
-        let actualValue = element.create(with: "id")
+    func testShouldReturnCreateRequest() {
+        let actualValue = element.create()
 
         XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
         XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.general.identifier)")
     }
 }

--- a/JamfKit/Tests/Session/Requests/MobileDevice/MobileDeviceRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/MobileDevice/MobileDeviceRequestsTests.swift
@@ -34,7 +34,7 @@ class MobileDeviceRequestsTests: XCTestCase {
     // MARK: - Tests
 
     func testShouldReturnReadAllRequest() {
-        let actualValue = MobileDevice.readAll()
+        let actualValue = MobileDevice.readAllRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -43,7 +43,7 @@ class MobileDeviceRequestsTests: XCTestCase {
     }
 
     func testShouldReturnCreateRequest() {
-        let actualValue = element.create()
+        let actualValue = element.createRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
@@ -52,7 +52,7 @@ class MobileDeviceRequestsTests: XCTestCase {
     }
 
     func testShouldReturnStaticReadRequestWithIdentifier() {
-        let actualValue = MobileDevice.read(identifier: "12345")
+        let actualValue = MobileDevice.readRequest(identifier: "12345")
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -61,7 +61,7 @@ class MobileDeviceRequestsTests: XCTestCase {
     }
 
     func testShouldReturnReadRequestWithIdentifier() {
-        let actualValue = element.read()
+        let actualValue = element.readRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -70,7 +70,7 @@ class MobileDeviceRequestsTests: XCTestCase {
     }
 
     func testShouldReturnReadRequestWithName() {
-        let actualValue = element.readWithName()
+        let actualValue = element.readRequestWithName()
         let encodedName = element.general.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
 
         XCTAssertNotNil(actualValue)
@@ -80,7 +80,7 @@ class MobileDeviceRequestsTests: XCTestCase {
     }
 
     func testShouldReturnReadRequestWithUdid() {
-        let actualValue = element.readWithUdid()
+        let actualValue = element.readRequestWithUdid()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -89,7 +89,7 @@ class MobileDeviceRequestsTests: XCTestCase {
     }
 
     func testShouldReturnReadRequestWithSerialNumber() {
-        let actualValue = element.readWithSerialNumber()
+        let actualValue = element.readRequestWithSerialNumber()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -98,7 +98,7 @@ class MobileDeviceRequestsTests: XCTestCase {
     }
 
     func testShouldReturnUpdateRequestWithIdentifier() {
-        let actualValue = element.update()
+        let actualValue = element.updateRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
@@ -107,7 +107,7 @@ class MobileDeviceRequestsTests: XCTestCase {
     }
 
     func testShouldReturnUpdateRequestWithName() {
-        let actualValue = element.updateWithName()
+        let actualValue = element.updateRequestWithName()
         let encodedName = element.general.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
 
         XCTAssertNotNil(actualValue)
@@ -117,7 +117,7 @@ class MobileDeviceRequestsTests: XCTestCase {
     }
 
     func testShouldReturnUpdateRequestWithUdid() {
-        let actualValue = element.updateWithUdid()
+        let actualValue = element.updateRequestWithUdid()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
@@ -126,7 +126,7 @@ class MobileDeviceRequestsTests: XCTestCase {
     }
 
     func testShouldReturnUpdateRequestWithSerialNumber() {
-        let actualValue = element.updateWithSerialNumber()
+        let actualValue = element.updateRequestWithSerialNumber()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
@@ -135,7 +135,7 @@ class MobileDeviceRequestsTests: XCTestCase {
     }
 
     func testShouldReturnDeleteRequestWithIdentifier() {
-        let actualValue = element.delete()
+        let actualValue = element.deleteRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
@@ -144,7 +144,7 @@ class MobileDeviceRequestsTests: XCTestCase {
     }
 
     func testShouldReturnDeleteRequestWithName() {
-        let actualValue = element.deleteWithName()
+        let actualValue = element.deleteRequestWithName()
         let encodedName = element.general.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
 
         XCTAssertNotNil(actualValue)
@@ -154,7 +154,7 @@ class MobileDeviceRequestsTests: XCTestCase {
     }
 
     func testShouldReturnDeleteRequestWithUdid() {
-        let actualValue = element.deleteWithUdid()
+        let actualValue = element.deleteRequestWithUdid()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
@@ -163,7 +163,7 @@ class MobileDeviceRequestsTests: XCTestCase {
     }
 
     func testShouldReturnDeleteRequestWithSerialNumber() {
-        let actualValue = element.deleteWithSerialNumber()
+        let actualValue = element.deleteRequestWithSerialNumber()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)

--- a/JamfKit/Tests/Session/Requests/MobileDevice/MobileDeviceRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/MobileDevice/MobileDeviceRequestsTests.swift
@@ -33,11 +33,141 @@ class MobileDeviceRequestsTests: XCTestCase {
 
     // MARK: - Tests
 
+    func testShouldReturnReadAllRequest() {
+        let actualValue = MobileDevice.readAll()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(MobileDevice.Endpoint)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
     func testShouldReturnCreateRequest() {
         let actualValue = element.create()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
         XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.general.identifier)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnStaticReadRequestWithIdentifier() {
+        let actualValue = MobileDevice.read(identifier: "12345")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(MobileDevice.Endpoint)/id/12345")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadRequestWithIdentifier() {
+        let actualValue = element.read()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.general.identifier)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadRequestWithName() {
+        let actualValue = element.readWithName()
+        let encodedName = element.general.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(encodedName)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadRequestWithUdid() {
+        let actualValue = element.readWithUdid()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/udid/\(element.general.udid)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadRequestWithSerialNumber() {
+        let actualValue = element.readWithSerialNumber()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/serialnumber/\(element.general.serialNumber)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnUpdateRequestWithIdentifier() {
+        let actualValue = element.update()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.general.identifier)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnUpdateRequestWithName() {
+        let actualValue = element.updateWithName()
+        let encodedName = element.general.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(encodedName)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnUpdateRequestWithUdid() {
+        let actualValue = element.updateWithUdid()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/udid/\(element.general.udid)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnUpdateRequestWithSerialNumber() {
+        let actualValue = element.updateWithSerialNumber()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/serialnumber/\(element.general.serialNumber)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnDeleteRequestWithIdentifier() {
+        let actualValue = element.delete()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.general.identifier)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnDeleteRequestWithName() {
+        let actualValue = element.deleteWithName()
+        let encodedName = element.general.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(encodedName)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnDeleteRequestWithUdid() {
+        let actualValue = element.deleteWithUdid()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/udid/\(element.general.udid)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnDeleteRequestWithSerialNumber() {
+        let actualValue = element.deleteWithSerialNumber()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/serialnumber/\(element.general.serialNumber)")
+        XCTAssertNil(actualValue?.httpBody)
     }
 }

--- a/JamfKit/Tests/Session/Requests/MobileDevice/MobileDeviceRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/MobileDevice/MobileDeviceRequestsTests.swift
@@ -1,0 +1,43 @@
+//
+//  MobileDeviceRequestsTests.swift
+//  JamfKit
+//
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+//
+
+import XCTest
+
+@testable import JamfKit
+
+class MobileDeviceRequestsTests: XCTestCase {
+
+    // MARK: - Constants
+
+    let subfolder = "MobileDevice/"
+    let defaultHost = "http://localhost"
+    let defaultUsername = "username"
+    let defaultPassword = "password"
+
+    // MARK: - Lifecycle
+
+    override func setUp() {
+        try? SessionManager.instance.configure(for: defaultHost, username: defaultUsername, password: defaultPassword)
+    }
+
+    override func tearDown() {
+        SessionManager.instance.clearConfiguration()
+    }
+
+    // MARK: - Tests
+
+    func testReturnCreateRequest() {
+        let payload = self.payload(for: "mobile_device", subfolder: subfolder)!
+        let element = MobileDevice(json: payload)!
+
+        let actualValue = element.create(with: "id")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.general.identifier)")
+    }
+}

--- a/JamfKit/Tests/Session/Requests/MobileDeviceGroup/MobileDeviceGroupRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/MobileDeviceGroup/MobileDeviceGroupRequestsTests.swift
@@ -34,7 +34,7 @@ class MobileDeviceGroupRequestsTests: XCTestCase {
     // MARK: - Tests
 
     func testShouldReturnCreateRequest() {
-        let actualValue = element.create()
+        let actualValue = element.createRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
@@ -43,7 +43,7 @@ class MobileDeviceGroupRequestsTests: XCTestCase {
     }
 
     func testShouldReturnReadAllRequest() {
-        let actualValue = MobileDeviceGroup.readAll()
+        let actualValue = MobileDeviceGroup.readAllRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -52,7 +52,7 @@ class MobileDeviceGroupRequestsTests: XCTestCase {
     }
 
     func testShouldReturnStaticReadRequestWithIdentifier() {
-        let actualValue = MobileDeviceGroup.read(identifier: "12345")
+        let actualValue = MobileDeviceGroup.readRequest(identifier: "12345")
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -61,7 +61,7 @@ class MobileDeviceGroupRequestsTests: XCTestCase {
     }
 
     func testShouldReturnReadRequestWithIdentifier() {
-        let actualValue = element.read()
+        let actualValue = element.readRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -69,8 +69,17 @@ class MobileDeviceGroupRequestsTests: XCTestCase {
         XCTAssertNil(actualValue?.httpBody)
     }
 
+    func testShouldReturnStaticReadRequestWithName() {
+        let actualValue = MobileDeviceGroup.readRequest(name: "Mobile Device Group")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(MobileDeviceGroup.Endpoint)/name/Mobile%20Device%20Group")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
     func testShouldReturnReadRequestWithName() {
-        let actualValue = element.readWithName()
+        let actualValue = element.readRequestWithName()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -79,7 +88,7 @@ class MobileDeviceGroupRequestsTests: XCTestCase {
     }
 
     func testShouldReturnUpdateRequestWithIdentifier() {
-        let actualValue = element.update()
+        let actualValue = element.updateRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
@@ -88,7 +97,7 @@ class MobileDeviceGroupRequestsTests: XCTestCase {
     }
 
     func testShouldReturnUpdateRequestWithName() {
-        let actualValue = element.updateWithName()
+        let actualValue = element.updateRequestWithName()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
@@ -97,7 +106,7 @@ class MobileDeviceGroupRequestsTests: XCTestCase {
     }
 
     func testShouldReturnStaticDeleteRequestWithIdentifier() {
-        let actualValue = MobileDeviceGroup.delete(identifier: "12345")
+        let actualValue = MobileDeviceGroup.deleteRequest(identifier: "12345")
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
@@ -106,7 +115,7 @@ class MobileDeviceGroupRequestsTests: XCTestCase {
     }
 
     func testShouldReturnDeleteRequestWithIdentifier() {
-        let actualValue = element.delete()
+        let actualValue = element.deleteRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
@@ -114,8 +123,17 @@ class MobileDeviceGroupRequestsTests: XCTestCase {
         XCTAssertNil(actualValue?.httpBody)
     }
 
+    func testShouldReturnStaticDeleteRequestWithName() {
+        let actualValue = MobileDeviceGroup.deleteRequest(name: "12345")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(MobileDeviceGroup.Endpoint)/name/12345")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
     func testShouldReturnDeleteRequestWithName() {
-        let actualValue = element.deleteWithName()
+        let actualValue = element.deleteRequestWithName()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)

--- a/JamfKit/Tests/Session/Requests/MobileDeviceGroup/MobileDeviceGroupRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/MobileDeviceGroup/MobileDeviceGroupRequestsTests.swift
@@ -1,0 +1,43 @@
+//
+//  MobileDeviceGroupRequestsTests.swift
+//  JamfKit
+//
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+//
+
+import XCTest
+
+@testable import JamfKit
+
+class MobileDeviceGroupRequestsTests: XCTestCase {
+
+    // MARK: - Constants
+
+    let subfolder = "MobileDeviceGroup/"
+    let defaultHost = "http://localhost"
+    let defaultUsername = "username"
+    let defaultPassword = "password"
+
+    // MARK: - Lifecycle
+
+    override func setUp() {
+        try? SessionManager.instance.configure(for: defaultHost, username: defaultUsername, password: defaultPassword)
+    }
+
+    override func tearDown() {
+        SessionManager.instance.clearConfiguration()
+    }
+
+    // MARK: - Tests
+
+    func testReturnCreateRequest() {
+        let payload = self.payload(for: "mobile_device_group_valid", subfolder: subfolder)!
+        let element = MobileDeviceGroup(json: payload)!
+
+        let actualValue = element.create()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+    }
+}

--- a/JamfKit/Tests/Session/Requests/MobileDeviceGroup/MobileDeviceGroupRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/MobileDeviceGroup/MobileDeviceGroupRequestsTests.swift
@@ -16,13 +16,15 @@ class MobileDeviceGroupRequestsTests: XCTestCase {
 
     let subfolder = "MobileDeviceGroup/"
     let defaultHost = "http://localhost"
-    let defaultUsername = "username"
-    let defaultPassword = "password"
+    var element: MobileDeviceGroup!
 
     // MARK: - Lifecycle
 
     override func setUp() {
-        try? SessionManager.instance.configure(for: defaultHost, username: defaultUsername, password: defaultPassword)
+        try? SessionManager.instance.configure(for: defaultHost, username: "username", password: "password")
+
+        let payload = self.payload(for: "mobile_device_group_valid", subfolder: subfolder)!
+        element = MobileDeviceGroup(json: payload)!
     }
 
     override func tearDown() {
@@ -31,13 +33,11 @@ class MobileDeviceGroupRequestsTests: XCTestCase {
 
     // MARK: - Tests
 
-    func testReturnCreateRequest() {
-        let payload = self.payload(for: "mobile_device_group_valid", subfolder: subfolder)!
-        let element = MobileDeviceGroup(json: payload)!
-
+    func testShouldReturnCreateRequest() {
         let actualValue = element.create()
 
         XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
         XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
     }
 }

--- a/JamfKit/Tests/Session/Requests/MobileDeviceGroup/MobileDeviceGroupRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/MobileDeviceGroup/MobileDeviceGroupRequestsTests.swift
@@ -39,5 +39,87 @@ class MobileDeviceGroupRequestsTests: XCTestCase {
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
         XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadAllRequest() {
+        let actualValue = MobileDeviceGroup.readAll()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(MobileDeviceGroup.Endpoint)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnStaticReadRequestWithIdentifier() {
+        let actualValue = MobileDeviceGroup.read(identifier: "12345")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(MobileDeviceGroup.Endpoint)/id/12345")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadRequestWithIdentifier() {
+        let actualValue = element.read()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadRequestWithName() {
+        let actualValue = element.readWithName()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(element.name)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnUpdateRequestWithIdentifier() {
+        let actualValue = element.update()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnUpdateRequestWithName() {
+        let actualValue = element.updateWithName()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(element.name)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnStaticDeleteRequestWithIdentifier() {
+        let actualValue = MobileDeviceGroup.delete(identifier: "12345")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(MobileDeviceGroup.Endpoint)/id/12345")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnDeleteRequestWithIdentifier() {
+        let actualValue = element.delete()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnDeleteRequestWithName() {
+        let actualValue = element.deleteWithName()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(element.name)")
+        XCTAssertNil(actualValue?.httpBody)
     }
 }

--- a/JamfKit/Tests/Session/Requests/NetbootServerRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/NetbootServerRequestsTests.swift
@@ -39,5 +39,90 @@ class NetbootServerRequestsTests: XCTestCase {
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
         XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadAllRequest() {
+        let actualValue = NetbootServer.readAll()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(NetbootServer.Endpoint)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnStaticReadRequestWithIdentifier() {
+        let actualValue = NetbootServer.read(identifier: "12345")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(NetbootServer.Endpoint)/id/12345")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadRequestWithIdentifier() {
+        let actualValue = element.read()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadRequestWithName() {
+        let actualValue = element.readWithName()
+        let encodedName = element.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(encodedName)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnUpdateRequestWithIdentifier() {
+        let actualValue = element.update()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnUpdateRequestWithName() {
+        let actualValue = element.updateWithName()
+        let encodedName = element.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(encodedName)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnStaticDeleteRequestWithIdentifier() {
+        let actualValue = NetbootServer.delete(identifier: "12345")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(NetbootServer.Endpoint)/id/12345")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnDeleteRequestWithIdentifier() {
+        let actualValue = element.delete()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnDeleteRequestWithName() {
+        let actualValue = element.deleteWithName()
+        let encodedName = element.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(encodedName)")
+        XCTAssertNil(actualValue?.httpBody)
     }
 }

--- a/JamfKit/Tests/Session/Requests/NetbootServerRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/NetbootServerRequestsTests.swift
@@ -16,13 +16,15 @@ class NetbootServerRequestsTests: XCTestCase {
 
     let subfolder = "NetbootServer/"
     let defaultHost = "http://localhost"
-    let defaultUsername = "username"
-    let defaultPassword = "password"
+    var element: NetbootServer!
 
     // MARK: - Lifecycle
 
     override func setUp() {
-        try? SessionManager.instance.configure(for: defaultHost, username: defaultUsername, password: defaultPassword)
+        try? SessionManager.instance.configure(for: defaultHost, username: "username", password: "password")
+
+        let payload = self.payload(for: "netboot_server_valid", subfolder: subfolder)!
+        element = NetbootServer(json: payload)!
     }
 
     override func tearDown() {
@@ -31,13 +33,11 @@ class NetbootServerRequestsTests: XCTestCase {
 
     // MARK: - Tests
 
-    func testReturnCreateRequest() {
-        let payload = self.payload(for: "netboot_server_valid", subfolder: subfolder)!
-        let element = NetbootServer(json: payload)!
-
+    func testShouldReturnCreateRequest() {
         let actualValue = element.create()
 
         XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
         XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
     }
 }

--- a/JamfKit/Tests/Session/Requests/NetbootServerRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/NetbootServerRequestsTests.swift
@@ -1,0 +1,43 @@
+//
+//  NetbootServerRequestsTests.swift
+//  JamfKit
+//
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+//
+
+import XCTest
+
+@testable import JamfKit
+
+class NetbootServerRequestsTests: XCTestCase {
+
+    // MARK: - Constants
+
+    let subfolder = "NetbootServer/"
+    let defaultHost = "http://localhost"
+    let defaultUsername = "username"
+    let defaultPassword = "password"
+
+    // MARK: - Lifecycle
+
+    override func setUp() {
+        try? SessionManager.instance.configure(for: defaultHost, username: defaultUsername, password: defaultPassword)
+    }
+
+    override func tearDown() {
+        SessionManager.instance.clearConfiguration()
+    }
+
+    // MARK: - Tests
+
+    func testReturnCreateRequest() {
+        let payload = self.payload(for: "netboot_server_valid", subfolder: subfolder)!
+        let element = NetbootServer(json: payload)!
+
+        let actualValue = element.create()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+    }
+}

--- a/JamfKit/Tests/Session/Requests/NetbootServerRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/NetbootServerRequestsTests.swift
@@ -34,7 +34,7 @@ class NetbootServerRequestsTests: XCTestCase {
     // MARK: - Tests
 
     func testShouldReturnCreateRequest() {
-        let actualValue = element.create()
+        let actualValue = element.createRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
@@ -43,7 +43,7 @@ class NetbootServerRequestsTests: XCTestCase {
     }
 
     func testShouldReturnReadAllRequest() {
-        let actualValue = NetbootServer.readAll()
+        let actualValue = NetbootServer.readAllRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -52,7 +52,7 @@ class NetbootServerRequestsTests: XCTestCase {
     }
 
     func testShouldReturnStaticReadRequestWithIdentifier() {
-        let actualValue = NetbootServer.read(identifier: "12345")
+        let actualValue = NetbootServer.readRequest(identifier: "12345")
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -61,7 +61,7 @@ class NetbootServerRequestsTests: XCTestCase {
     }
 
     func testShouldReturnReadRequestWithIdentifier() {
-        let actualValue = element.read()
+        let actualValue = element.readRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -69,8 +69,17 @@ class NetbootServerRequestsTests: XCTestCase {
         XCTAssertNil(actualValue?.httpBody)
     }
 
+    func testShouldReturnStaticReadRequestWithName() {
+        let actualValue = NetbootServer.readRequest(name: "Netboot Server")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(NetbootServer.Endpoint)/name/Netboot%20Server")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
     func testShouldReturnReadRequestWithName() {
-        let actualValue = element.readWithName()
+        let actualValue = element.readRequestWithName()
         let encodedName = element.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
 
         XCTAssertNotNil(actualValue)
@@ -80,7 +89,7 @@ class NetbootServerRequestsTests: XCTestCase {
     }
 
     func testShouldReturnUpdateRequestWithIdentifier() {
-        let actualValue = element.update()
+        let actualValue = element.updateRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
@@ -89,7 +98,7 @@ class NetbootServerRequestsTests: XCTestCase {
     }
 
     func testShouldReturnUpdateRequestWithName() {
-        let actualValue = element.updateWithName()
+        let actualValue = element.updateRequestWithName()
         let encodedName = element.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
 
         XCTAssertNotNil(actualValue)
@@ -99,7 +108,7 @@ class NetbootServerRequestsTests: XCTestCase {
     }
 
     func testShouldReturnStaticDeleteRequestWithIdentifier() {
-        let actualValue = NetbootServer.delete(identifier: "12345")
+        let actualValue = NetbootServer.deleteRequest(identifier: "12345")
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
@@ -108,7 +117,7 @@ class NetbootServerRequestsTests: XCTestCase {
     }
 
     func testShouldReturnDeleteRequestWithIdentifier() {
-        let actualValue = element.delete()
+        let actualValue = element.deleteRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
@@ -116,8 +125,17 @@ class NetbootServerRequestsTests: XCTestCase {
         XCTAssertNil(actualValue?.httpBody)
     }
 
+    func testShouldReturnStaticDeleteRequestWithName() {
+        let actualValue = NetbootServer.deleteRequest(name: "12345")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(NetbootServer.Endpoint)/name/12345")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
     func testShouldReturnDeleteRequestWithName() {
-        let actualValue = element.deleteWithName()
+        let actualValue = element.deleteRequestWithName()
         let encodedName = element.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
 
         XCTAssertNotNil(actualValue)

--- a/JamfKit/Tests/Session/Requests/Policy/PolicyRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/Policy/PolicyRequestsTests.swift
@@ -1,5 +1,5 @@
 //
-//  ComputerConfigurationRequestsTests.swift
+//  PolicyRequestsTests.swift
 //  JamfKit
 //
 //  Copyright © 2017-present JamfKit. All rights reserved.
@@ -10,21 +10,21 @@ import XCTest
 
 @testable import JamfKit
 
-class ComputerConfigurationRequestsTests: XCTestCase {
+class PolicyRequestsTests: XCTestCase {
 
     // MARK: - Constants
 
-    let subfolder = "ComputerConfiguration/"
+    let subfolder = "Policy/"
     let defaultHost = "http://localhost"
-    var element: ComputerConfiguration!
+    var element: Policy!
 
     // MARK: - Lifecycle
 
     override func setUp() {
         try? SessionManager.instance.configure(for: defaultHost, username: "username", password: "password")
 
-        let payload = self.payload(for: "computer_configuration", subfolder: subfolder)!
-        element = ComputerConfiguration(json: payload)!
+        let payload = self.payload(for: "policy", subfolder: subfolder)!
+        element = Policy(json: payload)!
     }
 
     override func tearDown() {
@@ -32,6 +32,15 @@ class ComputerConfigurationRequestsTests: XCTestCase {
     }
 
     // MARK: - Tests
+
+    func testShouldReturnReadAllRequest() {
+        let actualValue = Policy.readAll()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(Policy.Endpoint)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
 
     func testShouldReturnCreateRequest() {
         let actualValue = element.create()
@@ -42,21 +51,12 @@ class ComputerConfigurationRequestsTests: XCTestCase {
         XCTAssertNotNil(actualValue?.httpBody)
     }
 
-    func testShouldReturnReadAllRequest() {
-        let actualValue = ComputerConfiguration.readAll()
-
-        XCTAssertNotNil(actualValue)
-        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
-        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(ComputerConfiguration.Endpoint)")
-        XCTAssertNil(actualValue?.httpBody)
-    }
-
     func testShouldReturnStaticReadRequestWithIdentifier() {
-        let actualValue = ComputerConfiguration.read(identifier: "12345")
+        let actualValue = Policy.read(identifier: "12345")
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
-        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(ComputerConfiguration.Endpoint)/id/12345")
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(Policy.Endpoint)/id/12345")
         XCTAssertNil(actualValue?.httpBody)
     }
 
@@ -71,11 +71,10 @@ class ComputerConfigurationRequestsTests: XCTestCase {
 
     func testShouldReturnReadRequestWithName() {
         let actualValue = element.readWithName()
-        let encodedName = element.general.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
-        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(encodedName)")
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(element.general.name)")
         XCTAssertNil(actualValue?.httpBody)
     }
 
@@ -90,11 +89,10 @@ class ComputerConfigurationRequestsTests: XCTestCase {
 
     func testShouldReturnUpdateRequestWithName() {
         let actualValue = element.updateWithName()
-        let encodedName = element.general.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
-        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(encodedName)")
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(element.general.name)")
         XCTAssertNotNil(actualValue?.httpBody)
     }
 
@@ -109,11 +107,10 @@ class ComputerConfigurationRequestsTests: XCTestCase {
 
     func testShouldReturnDeleteRequestWithName() {
         let actualValue = element.deleteWithName()
-        let encodedName = element.general.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
-        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(encodedName)")
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(element.general.name)")
         XCTAssertNil(actualValue?.httpBody)
     }
 }

--- a/JamfKit/Tests/Session/Requests/Policy/PolicyRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/Policy/PolicyRequestsTests.swift
@@ -34,7 +34,7 @@ class PolicyRequestsTests: XCTestCase {
     // MARK: - Tests
 
     func testShouldReturnReadAllRequest() {
-        let actualValue = Policy.readAll()
+        let actualValue = Policy.readAllRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -43,7 +43,7 @@ class PolicyRequestsTests: XCTestCase {
     }
 
     func testShouldReturnCreateRequest() {
-        let actualValue = element.create()
+        let actualValue = element.createRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
@@ -52,7 +52,7 @@ class PolicyRequestsTests: XCTestCase {
     }
 
     func testShouldReturnStaticReadRequestWithIdentifier() {
-        let actualValue = Policy.read(identifier: "12345")
+        let actualValue = Policy.readRequest(identifier: "12345")
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -61,7 +61,7 @@ class PolicyRequestsTests: XCTestCase {
     }
 
     func testShouldReturnReadRequestWithIdentifier() {
-        let actualValue = element.read()
+        let actualValue = element.readRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -70,7 +70,7 @@ class PolicyRequestsTests: XCTestCase {
     }
 
     func testShouldReturnReadRequestWithName() {
-        let actualValue = element.readWithName()
+        let actualValue = element.readRequestWithName()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -79,7 +79,7 @@ class PolicyRequestsTests: XCTestCase {
     }
 
     func testShouldReturnUpdateRequestWithIdentifier() {
-        let actualValue = element.update()
+        let actualValue = element.updateRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
@@ -88,7 +88,7 @@ class PolicyRequestsTests: XCTestCase {
     }
 
     func testShouldReturnUpdateRequestWithName() {
-        let actualValue = element.updateWithName()
+        let actualValue = element.updateRequestWithName()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
@@ -97,7 +97,7 @@ class PolicyRequestsTests: XCTestCase {
     }
 
     func testShouldReturnDeleteRequestWithIdentifier() {
-        let actualValue = element.delete()
+        let actualValue = element.deleteRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
@@ -106,7 +106,7 @@ class PolicyRequestsTests: XCTestCase {
     }
 
     func testShouldReturnDeleteRequestWithName() {
-        let actualValue = element.deleteWithName()
+        let actualValue = element.deleteRequestWithName()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)

--- a/JamfKit/Tests/Session/Requests/PrinterRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/PrinterRequestsTests.swift
@@ -39,5 +39,90 @@ class PrinterRequestsTests: XCTestCase {
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
         XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadAllRequest() {
+        let actualValue = Printer.readAll()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(Printer.Endpoint)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnStaticReadRequestWithIdentifier() {
+        let actualValue = Printer.read(identifier: "12345")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(Printer.Endpoint)/id/12345")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadRequestWithIdentifier() {
+        let actualValue = element.read()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadRequestWithName() {
+        let actualValue = element.readWithName()
+        let encodedName = element.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(encodedName)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnUpdateRequestWithIdentifier() {
+        let actualValue = element.update()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnUpdateRequestWithName() {
+        let actualValue = element.updateWithName()
+        let encodedName = element.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(encodedName)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnStaticDeleteRequestWithIdentifier() {
+        let actualValue = Printer.delete(identifier: "12345")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(Printer.Endpoint)/id/12345")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnDeleteRequestWithIdentifier() {
+        let actualValue = element.delete()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnDeleteRequestWithName() {
+        let actualValue = element.deleteWithName()
+        let encodedName = element.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(encodedName)")
+        XCTAssertNil(actualValue?.httpBody)
     }
 }

--- a/JamfKit/Tests/Session/Requests/PrinterRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/PrinterRequestsTests.swift
@@ -34,7 +34,7 @@ class PrinterRequestsTests: XCTestCase {
     // MARK: - Tests
 
     func testShouldReturnCreateRequest() {
-        let actualValue = element.create()
+        let actualValue = element.createRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
@@ -43,7 +43,7 @@ class PrinterRequestsTests: XCTestCase {
     }
 
     func testShouldReturnReadAllRequest() {
-        let actualValue = Printer.readAll()
+        let actualValue = Printer.readAllRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -52,7 +52,7 @@ class PrinterRequestsTests: XCTestCase {
     }
 
     func testShouldReturnStaticReadRequestWithIdentifier() {
-        let actualValue = Printer.read(identifier: "12345")
+        let actualValue = Printer.readRequest(identifier: "12345")
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -61,7 +61,7 @@ class PrinterRequestsTests: XCTestCase {
     }
 
     func testShouldReturnReadRequestWithIdentifier() {
-        let actualValue = element.read()
+        let actualValue = element.readRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -69,8 +69,17 @@ class PrinterRequestsTests: XCTestCase {
         XCTAssertNil(actualValue?.httpBody)
     }
 
+    func testShouldReturnStaticReadRequestWithName() {
+        let actualValue = Printer.readRequest(name: "Printer")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(Printer.Endpoint)/name/Printer")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
     func testShouldReturnReadRequestWithName() {
-        let actualValue = element.readWithName()
+        let actualValue = element.readRequestWithName()
         let encodedName = element.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
 
         XCTAssertNotNil(actualValue)
@@ -80,7 +89,7 @@ class PrinterRequestsTests: XCTestCase {
     }
 
     func testShouldReturnUpdateRequestWithIdentifier() {
-        let actualValue = element.update()
+        let actualValue = element.updateRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
@@ -89,7 +98,7 @@ class PrinterRequestsTests: XCTestCase {
     }
 
     func testShouldReturnUpdateRequestWithName() {
-        let actualValue = element.updateWithName()
+        let actualValue = element.updateRequestWithName()
         let encodedName = element.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
 
         XCTAssertNotNil(actualValue)
@@ -99,7 +108,7 @@ class PrinterRequestsTests: XCTestCase {
     }
 
     func testShouldReturnStaticDeleteRequestWithIdentifier() {
-        let actualValue = Printer.delete(identifier: "12345")
+        let actualValue = Printer.deleteRequest(identifier: "12345")
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
@@ -108,7 +117,7 @@ class PrinterRequestsTests: XCTestCase {
     }
 
     func testShouldReturnDeleteRequestWithIdentifier() {
-        let actualValue = element.delete()
+        let actualValue = element.deleteRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
@@ -116,8 +125,17 @@ class PrinterRequestsTests: XCTestCase {
         XCTAssertNil(actualValue?.httpBody)
     }
 
+    func testShouldReturnStaticDeleteRequestWithName() {
+        let actualValue = Printer.deleteRequest(name: "12345")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(Printer.Endpoint)/name/12345")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
     func testShouldReturnDeleteRequestWithName() {
-        let actualValue = element.deleteWithName()
+        let actualValue = element.deleteRequestWithName()
         let encodedName = element.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
 
         XCTAssertNotNil(actualValue)

--- a/JamfKit/Tests/Session/Requests/PrinterRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/PrinterRequestsTests.swift
@@ -16,13 +16,15 @@ class PrinterRequestsTests: XCTestCase {
 
     let subfolder = "Printer/"
     let defaultHost = "http://localhost"
-    let defaultUsername = "username"
-    let defaultPassword = "password"
+    var element: Printer!
 
     // MARK: - Lifecycle
 
     override func setUp() {
-        try? SessionManager.instance.configure(for: defaultHost, username: defaultUsername, password: defaultPassword)
+        try? SessionManager.instance.configure(for: defaultHost, username: "username", password: "password")
+
+        let payload = self.payload(for: "printer_valid", subfolder: subfolder)!
+        element = Printer(json: payload)!
     }
 
     override func tearDown() {
@@ -31,13 +33,11 @@ class PrinterRequestsTests: XCTestCase {
 
     // MARK: - Tests
 
-    func testReturnCreateRequest() {
-        let payload = self.payload(for: "printer_valid", subfolder: subfolder)!
-        let element = Printer(json: payload)!
-
+    func testShouldReturnCreateRequest() {
         let actualValue = element.create()
 
         XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
         XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
     }
 }

--- a/JamfKit/Tests/Session/Requests/PrinterRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/PrinterRequestsTests.swift
@@ -1,0 +1,43 @@
+//
+//  PrinterRequestsTests.swift
+//  JamfKit
+//
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+//
+
+import XCTest
+
+@testable import JamfKit
+
+class PrinterRequestsTests: XCTestCase {
+
+    // MARK: - Constants
+
+    let subfolder = "Printer/"
+    let defaultHost = "http://localhost"
+    let defaultUsername = "username"
+    let defaultPassword = "password"
+
+    // MARK: - Lifecycle
+
+    override func setUp() {
+        try? SessionManager.instance.configure(for: defaultHost, username: defaultUsername, password: defaultPassword)
+    }
+
+    override func tearDown() {
+        SessionManager.instance.clearConfiguration()
+    }
+
+    // MARK: - Tests
+
+    func testReturnCreateRequest() {
+        let payload = self.payload(for: "printer_valid", subfolder: subfolder)!
+        let element = Printer(json: payload)!
+
+        let actualValue = element.create()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+    }
+}

--- a/JamfKit/Tests/Session/Requests/SMTPServerRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/SMTPServerRequestsTests.swift
@@ -53,7 +53,7 @@ class SMTPServerRequestsTests: XCTestCase {
         XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)")
         XCTAssertNil(actualValue?.httpBody)
     }
-    
+
     func testShouldReturnUpdateRequestWithIdentifier() {
         let actualValue = element.update()
 

--- a/JamfKit/Tests/Session/Requests/SMTPServerRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/SMTPServerRequestsTests.swift
@@ -1,0 +1,65 @@
+//
+//  SMTPServerRequestsTests.swift
+//  JamfKit
+//
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+//
+
+import XCTest
+
+@testable import JamfKit
+
+class SMTPServerRequestsTests: XCTestCase {
+
+    // MARK: - Constants
+
+    let subfolder = "SMTPServer/"
+    let defaultHost = "http://localhost"
+    var element: SMTPServer!
+
+    // MARK: - Lifecycle
+
+    override func setUp() {
+        try? SessionManager.instance.configure(for: defaultHost, username: "username", password: "password")
+
+        let payload = self.payload(for: "smtp_server", subfolder: subfolder)!
+        element = SMTPServer(json: payload)!
+    }
+
+    override func tearDown() {
+        SessionManager.instance.clearConfiguration()
+    }
+
+    // MARK: - Tests
+
+    func testShouldNotReturnReadAllRequest() {
+        let actualValue = SMTPServer.readAll()
+
+        XCTAssertNil(actualValue)
+    }
+
+    func testShouldNotReturnStaticReadRequestWithIdentifier() {
+        let actualValue = SMTPServer.read(identifier: "12345")
+
+        XCTAssertNil(actualValue)
+    }
+
+    func testShouldReturnReadRequest() {
+        let actualValue = element.read()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+    
+    func testShouldReturnUpdateRequestWithIdentifier() {
+        let actualValue = element.update()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+}

--- a/JamfKit/Tests/Session/Requests/SMTPServerRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/SMTPServerRequestsTests.swift
@@ -34,19 +34,19 @@ class SMTPServerRequestsTests: XCTestCase {
     // MARK: - Tests
 
     func testShouldNotReturnReadAllRequest() {
-        let actualValue = SMTPServer.readAll()
+        let actualValue = SMTPServer.readAllRequest()
 
         XCTAssertNil(actualValue)
     }
 
     func testShouldNotReturnStaticReadRequestWithIdentifier() {
-        let actualValue = SMTPServer.read(identifier: "12345")
+        let actualValue = SMTPServer.readRequest(identifier: "12345")
 
         XCTAssertNil(actualValue)
     }
 
     func testShouldReturnReadRequest() {
-        let actualValue = element.read()
+        let actualValue = element.readRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -55,7 +55,7 @@ class SMTPServerRequestsTests: XCTestCase {
     }
 
     func testShouldReturnUpdateRequestWithIdentifier() {
-        let actualValue = element.update()
+        let actualValue = element.updateRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)

--- a/JamfKit/Tests/Session/Requests/ScriptRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/ScriptRequestsTests.swift
@@ -1,0 +1,43 @@
+//
+//  ScriptRequestsTests.swift
+//  JamfKit
+//
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+//
+
+import XCTest
+
+@testable import JamfKit
+
+class ScriptRequestsTests: XCTestCase {
+
+    // MARK: - Constants
+
+    let subfolder = "Script/"
+    let defaultHost = "http://localhost"
+    let defaultUsername = "username"
+    let defaultPassword = "password"
+
+    // MARK: - Lifecycle
+
+    override func setUp() {
+        try? SessionManager.instance.configure(for: defaultHost, username: defaultUsername, password: defaultPassword)
+    }
+
+    override func tearDown() {
+        SessionManager.instance.clearConfiguration()
+    }
+
+    // MARK: - Tests
+
+    func testReturnCreateRequest() {
+        let payload = self.payload(for: "script_valid", subfolder: subfolder)!
+        let element = Script(json: payload)!
+
+        let actualValue = element.create()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+    }
+}

--- a/JamfKit/Tests/Session/Requests/ScriptRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/ScriptRequestsTests.swift
@@ -34,7 +34,7 @@ class ScriptRequestsTests: XCTestCase {
     // MARK: - Tests
 
     func testShouldReturnCreateRequest() {
-        let actualValue = element.create()
+        let actualValue = element.createRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
@@ -43,7 +43,7 @@ class ScriptRequestsTests: XCTestCase {
     }
 
     func testShouldReturnReadAllRequest() {
-        let actualValue = Script.readAll()
+        let actualValue = Script.readAllRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -52,7 +52,7 @@ class ScriptRequestsTests: XCTestCase {
     }
 
     func testShouldReturnStaticReadRequestWithIdentifier() {
-        let actualValue = Script.read(identifier: "12345")
+        let actualValue = Script.readRequest(identifier: "12345")
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -61,7 +61,7 @@ class ScriptRequestsTests: XCTestCase {
     }
 
     func testShouldReturnReadRequestWithIdentifier() {
-        let actualValue = element.read()
+        let actualValue = element.readRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -69,8 +69,17 @@ class ScriptRequestsTests: XCTestCase {
         XCTAssertNil(actualValue?.httpBody)
     }
 
+    func testShouldReturnStaticReadRequestWithName() {
+        let actualValue = Script.readRequest(name: "Script")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(Script.Endpoint)/name/Script")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
     func testShouldReturnReadRequestWithName() {
-        let actualValue = element.readWithName()
+        let actualValue = element.readRequestWithName()
         let encodedName = element.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
 
         XCTAssertNotNil(actualValue)
@@ -80,7 +89,7 @@ class ScriptRequestsTests: XCTestCase {
     }
 
     func testShouldReturnUpdateRequestWithIdentifier() {
-        let actualValue = element.update()
+        let actualValue = element.updateRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
@@ -89,7 +98,7 @@ class ScriptRequestsTests: XCTestCase {
     }
 
     func testShouldReturnUpdateRequestWithName() {
-        let actualValue = element.updateWithName()
+        let actualValue = element.updateRequestWithName()
         let encodedName = element.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
 
         XCTAssertNotNil(actualValue)
@@ -99,7 +108,7 @@ class ScriptRequestsTests: XCTestCase {
     }
 
     func testShouldReturnStaticDeleteRequestWithIdentifier() {
-        let actualValue = Script.delete(identifier: "12345")
+        let actualValue = Script.deleteRequest(identifier: "12345")
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
@@ -108,7 +117,7 @@ class ScriptRequestsTests: XCTestCase {
     }
 
     func testShouldReturnDeleteRequestWithIdentifier() {
-        let actualValue = element.delete()
+        let actualValue = element.deleteRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
@@ -116,8 +125,17 @@ class ScriptRequestsTests: XCTestCase {
         XCTAssertNil(actualValue?.httpBody)
     }
 
+    func testShouldReturnStaticDeleteRequestWithName() {
+        let actualValue = Script.deleteRequest(name: "12345")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(Script.Endpoint)/name/12345")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
     func testShouldReturnDeleteRequestWithName() {
-        let actualValue = element.deleteWithName()
+        let actualValue = element.deleteRequestWithName()
         let encodedName = element.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
 
         XCTAssertNotNil(actualValue)

--- a/JamfKit/Tests/Session/Requests/ScriptRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/ScriptRequestsTests.swift
@@ -31,13 +31,14 @@ class ScriptRequestsTests: XCTestCase {
 
     // MARK: - Tests
 
-    func testReturnCreateRequest() {
+    func testShouldReturnCreateRequest() {
         let payload = self.payload(for: "script_valid", subfolder: subfolder)!
         let element = Script(json: payload)!
 
         let actualValue = element.create()
 
         XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
         XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
     }
 }

--- a/JamfKit/Tests/Session/Requests/ScriptRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/ScriptRequestsTests.swift
@@ -16,13 +16,15 @@ class ScriptRequestsTests: XCTestCase {
 
     let subfolder = "Script/"
     let defaultHost = "http://localhost"
-    let defaultUsername = "username"
-    let defaultPassword = "password"
+    var element: Script!
 
     // MARK: - Lifecycle
 
     override func setUp() {
-        try? SessionManager.instance.configure(for: defaultHost, username: defaultUsername, password: defaultPassword)
+        try? SessionManager.instance.configure(for: defaultHost, username: "username", password: "password")
+
+        let payload = self.payload(for: "script_valid", subfolder: subfolder)!
+        element = Script(json: payload)!
     }
 
     override func tearDown() {
@@ -32,13 +34,95 @@ class ScriptRequestsTests: XCTestCase {
     // MARK: - Tests
 
     func testShouldReturnCreateRequest() {
-        let payload = self.payload(for: "script_valid", subfolder: subfolder)!
-        let element = Script(json: payload)!
-
         let actualValue = element.create()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
         XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadAllRequest() {
+        let actualValue = Script.readAll()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(Script.Endpoint)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnStaticReadRequestWithIdentifier() {
+        let actualValue = Script.read(identifier: "12345")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(Script.Endpoint)/id/12345")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadRequestWithIdentifier() {
+        let actualValue = element.read()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadRequestWithName() {
+        let actualValue = element.readWithName()
+        let encodedName = element.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(encodedName)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnUpdateRequestWithIdentifier() {
+        let actualValue = element.update()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnUpdateRequestWithName() {
+        let actualValue = element.updateWithName()
+        let encodedName = element.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(encodedName)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnStaticDeleteRequestWithIdentifier() {
+        let actualValue = Script.delete(identifier: "12345")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(Script.Endpoint)/id/12345")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnDeleteRequestWithIdentifier() {
+        let actualValue = element.delete()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnDeleteRequestWithName() {
+        let actualValue = element.deleteWithName()
+        let encodedName = element.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(encodedName)")
+        XCTAssertNil(actualValue?.httpBody)
     }
 }

--- a/JamfKit/Tests/Session/Requests/SessionManagerRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/SessionManagerRequestsTests.swift
@@ -2,7 +2,8 @@
 //  JamfKitSessionManagerRequestsTests.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 import XCTest
@@ -22,6 +23,10 @@ class SessionManagerRequestsTests: XCTestCase {
 
     override func setUp() {
         try? SessionManager.instance.configure(for: defaultHost, username: defaultUsername, password: defaultPassword)
+    }
+
+    override func tearDown() {
+        SessionManager.instance.clearConfiguration()
     }
 
     // MARK: - Tests
@@ -52,45 +57,5 @@ class SessionManagerRequestsTests: XCTestCase {
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue.value(forHTTPHeaderField: HttpHeader.authorization.rawValue), defaultAuthorizationHeader)
-    }
-
-    func testShouldReturnAuthentifiedCreateRequest() {
-        let defaultURL = URL(string: defaultHost)!
-
-        let actualValue = SessionManager.instance.createRequest(for: defaultURL)
-
-        XCTAssertNotNil(actualValue)
-        XCTAssertEqual(actualValue.value(forHTTPHeaderField: HttpHeader.authorization.rawValue), defaultAuthorizationHeader)
-        XCTAssertEqual(actualValue.httpMethod, HttpMethod.post.rawValue)
-    }
-
-    func testShouldReturnAuthentifiedReadRequest() {
-        let defaultURL = URL(string: defaultHost)!
-
-        let actualValue = SessionManager.instance.readRequest(for: defaultURL)
-
-        XCTAssertNotNil(actualValue)
-        XCTAssertEqual(actualValue.value(forHTTPHeaderField: HttpHeader.authorization.rawValue), defaultAuthorizationHeader)
-        XCTAssertEqual(actualValue.httpMethod, HttpMethod.get.rawValue)
-    }
-
-    func testShouldReturnAuthentifiedUpdateRequest() {
-        let defaultURL = URL(string: defaultHost)!
-
-        let actualValue = SessionManager.instance.updateRequest(for: defaultURL)
-
-        XCTAssertNotNil(actualValue)
-        XCTAssertEqual(actualValue.value(forHTTPHeaderField: HttpHeader.authorization.rawValue), defaultAuthorizationHeader)
-        XCTAssertEqual(actualValue.httpMethod, HttpMethod.put.rawValue)
-    }
-
-    func testShouldReturnAuthentifiedDeleteRequest() {
-        let defaultURL = URL(string: defaultHost)!
-
-        let actualValue = SessionManager.instance.deleteRequest(for: defaultURL)
-
-        XCTAssertNotNil(actualValue)
-        XCTAssertEqual(actualValue.value(forHTTPHeaderField: HttpHeader.authorization.rawValue), defaultAuthorizationHeader)
-        XCTAssertEqual(actualValue.httpMethod, HttpMethod.delete.rawValue)
     }
 }

--- a/JamfKit/Tests/Session/Requests/SiteRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/SiteRequestsTests.swift
@@ -16,13 +16,15 @@ class SiteRequestsTests: XCTestCase {
 
     let subfolder = "Site/"
     let defaultHost = "http://localhost"
-    let defaultUsername = "username"
-    let defaultPassword = "password"
+    var element: Site!
 
     // MARK: - Lifecycle
 
     override func setUp() {
-        try? SessionManager.instance.configure(for: defaultHost, username: defaultUsername, password: defaultPassword)
+        try? SessionManager.instance.configure(for: defaultHost, username: "username", password: "password")
+
+        let payload = self.payload(for: "site_valid", subfolder: subfolder)!
+        element = Site(json: payload)!
     }
 
     override func tearDown() {
@@ -31,13 +33,11 @@ class SiteRequestsTests: XCTestCase {
 
     // MARK: - Tests
 
-    func testReturnCreateRequest() {
-        let payload = self.payload(for: "site_valid", subfolder: subfolder)!
-        let element = Site(json: payload)!
-
+    func testShouldReturnCreateRequest() {
         let actualValue = element.create()
 
         XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
         XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
     }
 }

--- a/JamfKit/Tests/Session/Requests/SiteRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/SiteRequestsTests.swift
@@ -1,0 +1,43 @@
+//
+//  SiteRequestsTests.swift
+//  JamfKit
+//
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+//
+
+import XCTest
+
+@testable import JamfKit
+
+class SiteRequestsTests: XCTestCase {
+
+    // MARK: - Constants
+
+    let subfolder = "Site/"
+    let defaultHost = "http://localhost"
+    let defaultUsername = "username"
+    let defaultPassword = "password"
+
+    // MARK: - Lifecycle
+
+    override func setUp() {
+        try? SessionManager.instance.configure(for: defaultHost, username: defaultUsername, password: defaultPassword)
+    }
+
+    override func tearDown() {
+        SessionManager.instance.clearConfiguration()
+    }
+
+    // MARK: - Tests
+
+    func testReturnCreateRequest() {
+        let payload = self.payload(for: "site_valid", subfolder: subfolder)!
+        let element = Site(json: payload)!
+
+        let actualValue = element.create()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+    }
+}

--- a/JamfKit/Tests/Session/Requests/SiteRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/SiteRequestsTests.swift
@@ -34,7 +34,7 @@ class SiteRequestsTests: XCTestCase {
     // MARK: - Tests
 
     func testShouldReturnCreateRequest() {
-        let actualValue = element.create()
+        let actualValue = element.createRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
@@ -43,7 +43,7 @@ class SiteRequestsTests: XCTestCase {
     }
 
     func testShouldReturnReadAllRequest() {
-        let actualValue = Site.readAll()
+        let actualValue = Site.readAllRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -52,7 +52,7 @@ class SiteRequestsTests: XCTestCase {
     }
 
     func testShouldReturnStaticReadRequestWithIdentifier() {
-        let actualValue = Site.read(identifier: "12345")
+        let actualValue = Site.readRequest(identifier: "12345")
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -61,7 +61,7 @@ class SiteRequestsTests: XCTestCase {
     }
 
     func testShouldReturnReadRequestWithIdentifier() {
-        let actualValue = element.read()
+        let actualValue = element.readRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -69,8 +69,17 @@ class SiteRequestsTests: XCTestCase {
         XCTAssertNil(actualValue?.httpBody)
     }
 
+    func testShouldReturnStaticReadRequestWithName() {
+        let actualValue = Site.readRequest(name: "Site")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(Site.Endpoint)/name/Site")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
     func testShouldReturnReadRequestWithName() {
-        let actualValue = element.readWithName()
+        let actualValue = element.readRequestWithName()
         let encodedName = element.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
 
         XCTAssertNotNil(actualValue)
@@ -80,7 +89,7 @@ class SiteRequestsTests: XCTestCase {
     }
 
     func testShouldReturnUpdateRequestWithIdentifier() {
-        let actualValue = element.update()
+        let actualValue = element.updateRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
@@ -89,7 +98,7 @@ class SiteRequestsTests: XCTestCase {
     }
 
     func testShouldReturnUpdateRequestWithName() {
-        let actualValue = element.updateWithName()
+        let actualValue = element.updateRequestWithName()
         let encodedName = element.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
 
         XCTAssertNotNil(actualValue)
@@ -99,7 +108,7 @@ class SiteRequestsTests: XCTestCase {
     }
 
     func testShouldReturnStaticDeleteRequestWithIdentifier() {
-        let actualValue = Site.delete(identifier: "12345")
+        let actualValue = Site.deleteRequest(identifier: "12345")
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
@@ -108,7 +117,7 @@ class SiteRequestsTests: XCTestCase {
     }
 
     func testShouldReturnDeleteRequestWithIdentifier() {
-        let actualValue = element.delete()
+        let actualValue = element.deleteRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
@@ -116,8 +125,17 @@ class SiteRequestsTests: XCTestCase {
         XCTAssertNil(actualValue?.httpBody)
     }
 
+    func testShouldReturnStaticDeleteRequestWithName() {
+        let actualValue = Site.deleteRequest(name: "12345")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(Site.Endpoint)/name/12345")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
     func testShouldReturnDeleteRequestWithName() {
-        let actualValue = element.deleteWithName()
+        let actualValue = element.deleteRequestWithName()
         let encodedName = element.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
 
         XCTAssertNotNil(actualValue)

--- a/JamfKit/Tests/Session/Requests/SiteRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/SiteRequestsTests.swift
@@ -39,5 +39,90 @@ class SiteRequestsTests: XCTestCase {
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
         XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadAllRequest() {
+        let actualValue = Site.readAll()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(Site.Endpoint)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnStaticReadRequestWithIdentifier() {
+        let actualValue = Site.read(identifier: "12345")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(Site.Endpoint)/id/12345")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadRequestWithIdentifier() {
+        let actualValue = element.read()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadRequestWithName() {
+        let actualValue = element.readWithName()
+        let encodedName = element.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(encodedName)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnUpdateRequestWithIdentifier() {
+        let actualValue = element.update()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnUpdateRequestWithName() {
+        let actualValue = element.updateWithName()
+        let encodedName = element.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(encodedName)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnStaticDeleteRequestWithIdentifier() {
+        let actualValue = Site.delete(identifier: "12345")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(Site.Endpoint)/id/12345")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnDeleteRequestWithIdentifier() {
+        let actualValue = element.delete()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnDeleteRequestWithName() {
+        let actualValue = element.deleteWithName()
+        let encodedName = element.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(encodedName)")
+        XCTAssertNil(actualValue?.httpBody)
     }
 }

--- a/JamfKit/Tests/Session/Requests/UserRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/UserRequestsTests.swift
@@ -39,5 +39,114 @@ class UserRequestsTests: XCTestCase {
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
         XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadAllRequest() {
+        let actualValue = User.readAll()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(User.Endpoint)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnStaticReadRequestWithIdentifier() {
+        let actualValue = User.read(identifier: "12345")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(User.Endpoint)/id/12345")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadRequestWithIdentifier() {
+        let actualValue = element.read()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadRequestWithName() {
+        let actualValue = element.readWithName()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(element.name)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnReadRequestWithEmail() {
+        let actualValue = element.readWithEmail()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/email/\(element.email)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnUpdateRequestWithIdentifier() {
+        let actualValue = element.update()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnUpdateRequestWithName() {
+        let actualValue = element.updateWithName()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(element.name)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnUpdateRequestWithEmail() {
+        let actualValue = element.updateWithEmail()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/email/\(element.email)")
+        XCTAssertNotNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnStaticDeleteRequestWithIdentifier() {
+        let actualValue = User.delete(identifier: "12345")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(User.Endpoint)/id/12345")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnDeleteRequestWithIdentifier() {
+        let actualValue = element.delete()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnDeleteRequestWithName() {
+        let actualValue = element.deleteWithName()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/name/\(element.name)")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
+    func testShouldReturnDeleteRequestWithEmail() {
+        let actualValue = element.deleteWithEmail()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/email/\(element.email)")
+        XCTAssertNil(actualValue?.httpBody)
     }
 }

--- a/JamfKit/Tests/Session/Requests/UserRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/UserRequestsTests.swift
@@ -1,0 +1,43 @@
+//
+//  UserRequestsTests.swift
+//  JamfKit
+//
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+//
+
+import XCTest
+
+@testable import JamfKit
+
+class UserRequestsTests: XCTestCase {
+
+    // MARK: - Constants
+
+    let subfolder = "User/"
+    let defaultHost = "http://localhost"
+    let defaultUsername = "username"
+    let defaultPassword = "password"
+
+    // MARK: - Lifecycle
+
+    override func setUp() {
+        try? SessionManager.instance.configure(for: defaultHost, username: defaultUsername, password: defaultPassword)
+    }
+
+    override func tearDown() {
+        SessionManager.instance.clearConfiguration()
+    }
+
+    // MARK: - Tests
+
+    func testReturnCreateRequest() {
+        let payload = self.payload(for: "user_valid", subfolder: subfolder)!
+        let element = User(json: payload)!
+
+        let actualValue = element.create()
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
+    }
+}

--- a/JamfKit/Tests/Session/Requests/UserRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/UserRequestsTests.swift
@@ -16,13 +16,15 @@ class UserRequestsTests: XCTestCase {
 
     let subfolder = "User/"
     let defaultHost = "http://localhost"
-    let defaultUsername = "username"
-    let defaultPassword = "password"
+    var element: User!
 
     // MARK: - Lifecycle
 
     override func setUp() {
-        try? SessionManager.instance.configure(for: defaultHost, username: defaultUsername, password: defaultPassword)
+        try? SessionManager.instance.configure(for: defaultHost, username: "username", password: "password")
+
+        let payload = self.payload(for: "user_valid", subfolder: subfolder)!
+        element = User(json: payload)!
     }
 
     override func tearDown() {
@@ -31,13 +33,11 @@ class UserRequestsTests: XCTestCase {
 
     // MARK: - Tests
 
-    func testReturnCreateRequest() {
-        let payload = self.payload(for: "user_valid", subfolder: subfolder)!
-        let element = User(json: payload)!
-
+    func testShouldReturnCreateRequest() {
         let actualValue = element.create()
 
         XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
         XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(element.endpoint)/id/\(element.identifier)")
     }
 }

--- a/JamfKit/Tests/Session/Requests/UserRequestsTests.swift
+++ b/JamfKit/Tests/Session/Requests/UserRequestsTests.swift
@@ -34,7 +34,7 @@ class UserRequestsTests: XCTestCase {
     // MARK: - Tests
 
     func testShouldReturnCreateRequest() {
-        let actualValue = element.create()
+        let actualValue = element.createRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.post.rawValue)
@@ -43,7 +43,7 @@ class UserRequestsTests: XCTestCase {
     }
 
     func testShouldReturnReadAllRequest() {
-        let actualValue = User.readAll()
+        let actualValue = User.readAllRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -52,7 +52,7 @@ class UserRequestsTests: XCTestCase {
     }
 
     func testShouldReturnStaticReadRequestWithIdentifier() {
-        let actualValue = User.read(identifier: "12345")
+        let actualValue = User.readRequest(identifier: "12345")
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -61,7 +61,7 @@ class UserRequestsTests: XCTestCase {
     }
 
     func testShouldReturnReadRequestWithIdentifier() {
-        let actualValue = element.read()
+        let actualValue = element.readRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -69,8 +69,17 @@ class UserRequestsTests: XCTestCase {
         XCTAssertNil(actualValue?.httpBody)
     }
 
+    func testShouldReturnStaticReadRequestWithName() {
+        let actualValue = User.readRequest(name: "User")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(User.Endpoint)/name/User")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
     func testShouldReturnReadRequestWithName() {
-        let actualValue = element.readWithName()
+        let actualValue = element.readRequestWithName()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -78,8 +87,17 @@ class UserRequestsTests: XCTestCase {
         XCTAssertNil(actualValue?.httpBody)
     }
 
+    func testShouldReturnStaticReadRequestWithEmail() {
+        let actualValue = User.readRequest(email: "john.appleseed@apple.com")
+
+        XCTAssertNotNil(actualValue)
+        XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
+        XCTAssertEqual(actualValue?.url?.absoluteString, "\(defaultHost)/\(User.Endpoint)/email/john.appleseed@apple.com")
+        XCTAssertNil(actualValue?.httpBody)
+    }
+
     func testShouldReturnReadRequestWithEmail() {
-        let actualValue = element.readWithEmail()
+        let actualValue = element.readRequestWithEmail()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.get.rawValue)
@@ -88,7 +106,7 @@ class UserRequestsTests: XCTestCase {
     }
 
     func testShouldReturnUpdateRequestWithIdentifier() {
-        let actualValue = element.update()
+        let actualValue = element.updateRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
@@ -97,7 +115,7 @@ class UserRequestsTests: XCTestCase {
     }
 
     func testShouldReturnUpdateRequestWithName() {
-        let actualValue = element.updateWithName()
+        let actualValue = element.updateRequestWithName()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
@@ -106,7 +124,7 @@ class UserRequestsTests: XCTestCase {
     }
 
     func testShouldReturnUpdateRequestWithEmail() {
-        let actualValue = element.updateWithEmail()
+        let actualValue = element.updateRequestWithEmail()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.put.rawValue)
@@ -115,7 +133,7 @@ class UserRequestsTests: XCTestCase {
     }
 
     func testShouldReturnStaticDeleteRequestWithIdentifier() {
-        let actualValue = User.delete(identifier: "12345")
+        let actualValue = User.deleteRequest(identifier: "12345")
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
@@ -124,7 +142,7 @@ class UserRequestsTests: XCTestCase {
     }
 
     func testShouldReturnDeleteRequestWithIdentifier() {
-        let actualValue = element.delete()
+        let actualValue = element.deleteRequest()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
@@ -133,7 +151,7 @@ class UserRequestsTests: XCTestCase {
     }
 
     func testShouldReturnDeleteRequestWithName() {
-        let actualValue = element.deleteWithName()
+        let actualValue = element.deleteRequestWithName()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)
@@ -142,7 +160,7 @@ class UserRequestsTests: XCTestCase {
     }
 
     func testShouldReturnDeleteRequestWithEmail() {
-        let actualValue = element.deleteWithEmail()
+        let actualValue = element.deleteRequestWithEmail()
 
         XCTAssertNotNil(actualValue)
         XCTAssertEqual(actualValue?.httpMethod, HttpMethod.delete.rawValue)

--- a/JamfKit/Tests/Session/SessionManagerTests.swift
+++ b/JamfKit/Tests/Session/SessionManagerTests.swift
@@ -61,35 +61,35 @@ class SessionManagerTests: XCTestCase {
         XCTAssertEqual(SessionManager.instance.authorizationHeader, "")
     }
 
-    func testShouldPerformThrowingConnectivityCheckWithEmptyConfiguration() {
-        SessionManager.instance.clearConfiguration()
-
-        XCTAssertThrowsError(try SessionManager.instance.performConnectivityCheck { result in
-            XCTAssertFalse(result)
-        })
-    }
-
-    func testShouldPerformFailingConnectivityCheckWithEmptyHost() {
-        try? SessionManager.instance.configure(for: "", username: defaultUsername, password: defaultPassword)
-
-        try? SessionManager.instance.performConnectivityCheck { result in
-            XCTAssertFalse(result)
-        }
-    }
-
-    func testShouldPerformFailingConnectivityCheckWithEmptyUsername() {
-        try? SessionManager.instance.configure(for: self.defaultHost, username: "", password: defaultPassword)
-
-        try? SessionManager.instance.performConnectivityCheck { result in
-            XCTAssertFalse(result)
-        }
-    }
-
-    func testShouldPerformFailingConnectivityCheckWithEmptyPassword() {
-        try? SessionManager.instance.configure(for: self.defaultHost, username: defaultUsername, password: "")
-
-        try? SessionManager.instance.performConnectivityCheck { result in
-            XCTAssertFalse(result)
-        }
-    }
+//    func testShouldPerformThrowingConnectivityCheckWithEmptyConfiguration() {
+//        SessionManager.instance.clearConfiguration()
+//
+//        XCTAssertThrowsError(try SessionManager.instance.performConnectivityCheck { result in
+//            XCTAssertFalse(result)
+//        })
+//    }
+//
+//    func testShouldPerformFailingConnectivityCheckWithEmptyHost() {
+//        try? SessionManager.instance.configure(for: "", username: defaultUsername, password: defaultPassword)
+//
+//        try? SessionManager.instance.performConnectivityCheck { result in
+//            XCTAssertFalse(result)
+//        }
+//    }
+//
+//    func testShouldPerformFailingConnectivityCheckWithEmptyUsername() {
+//        try? SessionManager.instance.configure(for: self.defaultHost, username: "", password: defaultPassword)
+//
+//        try? SessionManager.instance.performConnectivityCheck { result in
+//            XCTAssertFalse(result)
+//        }
+//    }
+//
+//    func testShouldPerformFailingConnectivityCheckWithEmptyPassword() {
+//        try? SessionManager.instance.configure(for: self.defaultHost, username: defaultUsername, password: "")
+//
+//        try? SessionManager.instance.performConnectivityCheck { result in
+//            XCTAssertFalse(result)
+//        }
+//    }
 }

--- a/JamfKit/Tests/Session/SessionManagerTests.swift
+++ b/JamfKit/Tests/Session/SessionManagerTests.swift
@@ -2,7 +2,8 @@
 //  JamfKitSessionManagerTests.swift
 //  JamfKit
 //
-//  Copyright © 2018 JamfKit. All rights reserved.
+//  Copyright © 2017-present JamfKit. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 //
 
 import XCTest
@@ -20,8 +21,8 @@ class SessionManagerTests: XCTestCase {
 
     // MARK: - Lifecycle
 
-    override func setUp() {
-
+    override func tearDown() {
+        SessionManager.instance.clearConfiguration()
     }
 
     // MARK: - Tests

--- a/README.md
+++ b/README.md
@@ -8,10 +8,9 @@
 
 [![Travis branch](https://img.shields.io/travis/Ethenyl/JamfKit/master.svg?style=flat-square)](https://travis-ci.org/Ethenyl/JamfKit)
 [![Codecov](https://img.shields.io/codecov/c/github/Ethenyl/JamfKit.svg?style=flat-square)](https://codecov.io/gh/Ethenyl/JamfKit)
+[![Codacy grade](https://img.shields.io/codacy/grade/9f7907afc4884c2c9acbf1dc9412519d.svg?style=flat-square)]()
 [![Carthage compatible](https://img.shields.io/badge/carthage-compatible-4BC51D.svg?style=flat-square)](https://github.com/Carthage/Carthage)
 [![CocoaPods](https://img.shields.io/cocoapods/v/JAMFKit.svg?style=flat-square)](https://cocoapods.org/pods/JamfKit)
-
-[![GitHub license](https://img.shields.io/github/license/Ethenyl/JamfKit.svg?style=flat-square)](https://github.com/Ethenyl/JamfKit/blob/master/LICENSE)
 
 `JamfKit` is an iOS / macOS framework to communicate with the JSS API offered by any Jamf host.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 
 - [x] Includes JSON encoding / decoding support for most of the JSS objects
 - [x] Includes Objective-C support
-- [x] Includes Swift 4 support
+- [x] Includes Swift 4+ support
 - [x] Includes ready-for-consumption CRUD `URLRequest` for JSS endpoints
 - [x] Includes demonstration playgrounds for class handling or request generation
 
@@ -134,17 +134,17 @@ By adhering to the different CRUD protocols (`Creatable`, `Readable`, `Updatable
 
 You'll find below the basic functions to get `URLRequest`:
 
-|Function|Type|HTTP Method|Example|
-|-----|:-----:|:-----:|-----|
-|`create()`|`instance`|`POST`|http://jamf.com/jss/objects/1|
-|`readAll()`|`static`|`GET`|http://jamf.com/jss/objects|
-|`read(identifier:)`|`static`|`GET`|http://jamf.com/jss/objects/1|
-|`read()`|`instance`|`GET`|http://jamf.com/jss/objects/1|
-|`update()`|`instance`|`PUT`|http://jamf.com/jss/objects/1|
-|`delete(identifier:)`|`static`|`DELETE`|http://jamf.com/jss/objects/1|
-|`delete()`|`instance`|`DELETE`|http://jamf.com/jss/objects/1|
+|Function|Type|HTTP Method|Example|Output|
+|-----|:-----:|:-----:|-----|------|
+|`createRequest()`|`instance`|`POST`|`building.createRequest()`|`http://jss.host/jss/objects/1`|
+|`readAllRequest()`|`static`|`GET`|`Building.readAllRequest()`|`http://jamf.com/jss/objects`|
+|`readRequest(identifier:)`|`static`|`GET`|`Building.readRequest(identifier: "12345")`|`http://jamf.com/jss/objects/1`|
+|`readRequest()`|`instance`|`GET`|`building.readRequest()`|`http://jamf.com/jss/objects/1`|
+|`updateRequest()`|`instance`|`PUT`|`building.updateRequest()`|`http://jamf.com/jss/objects/1`|
+|`deleteRequest(identifier:)`|`static`|`DELETE`|`Building.deleteRequest(identifier: "12345")`|`http://jamf.com/jss/objects/1`|
+|`deleteRequest()`|`instance`|`DELETE`|`building.deleteRequest()`|`http://jamf.com/jss/objects/1`|
 
-Some objects will offer variants of those requests, like `MobileDevice` with `readWithName()` or `readWithSerialNumber()` (with both `static` and `instance` variants).
+Some objects will offer variants of those requests, like `MobileDevice` with `readRequestWithName()` or `deleteRequestWithSerialNumber()` (with both `static` and `instance` variants).
 
 ## Contributing ##
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
   - [Protocols](#protocols)
   - [Classes](#classes)
 - [Usage](#usage)
-  - [First steps](#first-steps)
+  - [Getting started](#getting-started)
 - [Contributing](#contributing)
 - [Code of conduct](#code-of-conduct)
 - [FAQ](#faq)
@@ -35,19 +35,17 @@
 
 ## Features ##
 
-🚧 &nbsp;**In progress, list will be updated as features are implemented** 🚧
-
-- [ ] Includes JSON encoding / decoding support for most of the JSS objects
+- [x] Includes JSON encoding / decoding support for most of the JSS objects
 - [x] Includes Objective-C support
 - [x] Includes Swift 4 support
-- [ ] Includes ready-for-consumption `URLRequest` for JSS endpoints
-- [ ] Includes demonstration playgrounds
+- [x] Includes ready-for-consumption CRUD `URLRequest` for JSS endpoints
+- [x] Includes demonstration playgrounds for class handling or request generation
 
 ## Compatibilities ##
 
 - iOS 9+ / macOS 10.10+
-- XCode 8.3+
-- Objective-C / Swift 3.1+
+- XCode 9.2+
+- Objective-C / Swift 4.1+
 
 ## Installation ##
 
@@ -73,7 +71,7 @@ platform :ios, '10.0'
 use_frameworks!
 
 target '<Your Target Name>' do
-    pod 'JamfKit'
+    pod 'JAMFKit'
 end
 ```
 
@@ -85,104 +83,80 @@ Then run the following command:
 
 ### Protocols ###
 
-#### Identifiable ####
+|Protocol|Description|
+|-----|-----|
+|`Endpoint`|Represents any JSS object that is matched by a JSS endpoint.|
+|`Identifiable`|Represents any JSS object that can be identified (either by ID or by name).|
+|`Requestable`|Represents an object that can be used to perform requests with any JSS endpoint.|
+|`Subset`|Represents any JSS object that contains a general object that can identify it.|
 
-Represents all objects that can be received from / sent to the Jamf host. Its exposes two criticals elements:
+#### Requestable conformance ####
 
-- An failable initializer that takes a JSON payload and return the instantiated `Identifiable` object
-- A function to return the JSON payload that represents the instance of the `Identifiable` object
+ The class that conform to `Requestable` exposes the following elements:
+
+- An failable initializer that takes a JSON payload and return the instantiated object
+- A function to return the JSON payload that represents the instance of the object
 
 ### Classes ###
 
-#### BaseObject ####
-
-Represents the common denominator between most of the JSS objects which must contains at least an `identifier` and a `name` properties.
-
-#### Building ####
-
-Represents a physical building.
-
-#### Computer ####
-
-Represents a computer managed by Jamf, contains the general / location / purchasing information about the hardware.
-
-#### Computer command ####
-
-Represents a logical command that can be executed on any hardware element manageg by Jamf.
-
-#### Computer group ####
-
-Represents a group of computers managed by Jamf, contains grouping information.
-
-#### Department ####
-
-Represents a physical department.
-
-#### Directory binding ####
-
-Represents a logical binding between a computer and an active directory user.
-
-#### Mobile device ####
-
-Represents a mobile device managed by Jamf, contains the general information about the device.
-
-#### Mobile device group ####
-
-Represents a group of mobile devices managed by Jamf, contains grouping information.
-
-#### Netboot server ####
-
-Represents a physical netboot server, contains information about the server and it's configuration.
-
-#### Network segment ####
-
-Represents a physical network segment, contains information about the segment and it's configuration.
-
-#### Package ####
-
-Represents a logical application package, contains information about the application requirements and capabilities.
-
-#### Partition ####
-
-Represents a logical partition for an hard drive installed inside an hardware element managed by Jamf.
-
-#### Policy ####
-
-Reprents as logical policy that can be applied to any hardware element managed by Jamf.
-
-#### Precise date ####
-
-Represents a logical date within JSS api, contains 3 properties, the date itself, an epoch version of the date and an UTC version of the date.
-
-#### Printer ####
-
-Represents a physical printer, contains information about the printer and it's configuration.
-
-#### Script ####
-
-Represents a logical script that can be executed on one (or more) machine managed by Jamf.
-
-#### Site ####
-
-Represents a physical location (building, office, etc.).
-
-#### SMTP server ####
-
-Represents a physical SMTP server, contains information about the server and it's configuration.
-
-#### User ####
-
-Represents a Jamf user and contains the identification properties that are required to contact the actual user and identify the hardware devices assigned to him / her.
+|Class|Desscription|
+|-----|-----|
+|`BaseObject`|Represents the common denominator between most of the JSS objects which must contains at least an `identifier` and a `name` properties.|
+|`Building`|Represents a physical building.|
+|`Computer`|Represents a computer managed by Jamf, contains the general / location / purchasing information about the hardware.|
+|`ComputerCommand`|Represents a logical command that can be executed on any hardware element manageg by Jamf.|
+|`ComputerGroup`|Represents a group of computers managed by Jamf, contains grouping information.|
+|`Department`|Represents a physical department.|
+|`DirectoryBinding`|Represents a logical binding between a computer and an active directory user.|
+|`MobileDevice`|Represents a mobile device managed by Jamf, contains the general information about the device.|
+|`MobileDeviceGroup`|Represents a group of mobile devices managed by Jamf, contains grouping information.|
+|`NetbootServer`|Represents a physical netboot server, contains information about the server and it's configuration.|
+|`NetworkSegment`|Represents a physical network segment, contains information about the segment and it's configuration.|
+|`Package`|Represents a logical application package, contains information about the application requirements and capabilities.|
+|`Partition`|Represents a logical partition for an hard drive installed inside an hardware element managed by Jamf.|
+|`Policy`|Reprents as logical policy that can be applied to any hardware element managed by Jamf.|
+|`PreciseDate`|Represents a logical date within JSS api, contains 3 properties, the date itself, an epoch variant of the date and an UTC version of the date.|
+|`Printer`|Represents a physical printer, contains information about the printer and it's configuration.|
+|`Script`|Represents a logical script that can be executed on one (or more) machine managed by Jamf.|
+|`Site`|Represents a physical location (building, office, etc.).|
+|`SMTPServer`|Represents the physical SMTP server configuration.|
+|`User`|Represents a Jamf user and contains the identification properties that are required to contact the actual user and identify the hardware devices assigned to him / her.|
 
 ## Usage ##
 
-### First steps ###
+### Getting started ###
 
-🚧 &nbsp;**In progress, will be updated when URL requests will be available** 🚧
+#### Playgrounds ####
+
+To get a quick look on how you can use `JamfKit` in your `Jamf` related features, you can check the `Playgrounds` included within the workspace.
+
+Also check the unit tests, they should cover most of your needs.
+
+#### Models ####
+
+Most of the classes can be initialized with the bare minimul values, all the properties are then available for modification.
+
+#### Requests ####
+
+By adhering to the different CRUD protocols (`Creatable`, `Readable`, `Updatable` & `Deletable`), most of the JSS objects listed above are capable of supplying varying `URLRequest` that should fit any needs.
+
+You'll find below the basic functions to get `URLRequest`:
+
+|Function|Type|HTTP Method|Example|
+|-----|:-----:|:-----:|-----|
+|`create()`|`instance`|`POST`|http://jamf.com/jss/objects/1|
+|`readAll()`|`static`|`GET`|http://jamf.com/jss/objects|
+|`read(identifier:)`|`static`|`GET`|http://jamf.com/jss/objects/1|
+|`read()`|`instance`|`GET`|http://jamf.com/jss/objects/1|
+|`update()`|`instance`|`PUT`|http://jamf.com/jss/objects/1|
+|`delete(identifier:)`|`static`|`DELETE`|http://jamf.com/jss/objects/1|
+|`delete()`|`instance`|`DELETE`|http://jamf.com/jss/objects/1|
+
+Some objects will offer variants of those requests, like `MobileDevice` with `readWithName()` or `readWithSerialNumber()` (with both `static` and `instance` variants).
 
 ## Contributing ##
 
-So, I heard you want to help improve `JamfKit`? That's great! Any useful contribution is welcome!
+So, you want to help improve `JamfKit`? That's great! Any useful contribution is welcome!
 
 Check [CONTRIBUTING](https://github.com/Ethenyl/JamfKit/blob/master/CONTRIBUTING.md) for more details on how you can contribute to `JamfKit`.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align="center"><img src="Assets/JamfKit_256.png" alt="JamfKit"></p>
 
-![Swift](https://img.shields.io/badge/Swift-3.1+-lightgrey.svg?style=flat-square)
+![Swift](https://img.shields.io/badge/Swift-4.1+-lightgrey.svg?style=flat-square)
 ![iOS](https://img.shields.io/badge/iOS-9+-lightgrey.svg?style=flat-square)
 ![macOS](https://img.shields.io/badge/macOS-10.10+-lightgrey.svg?style=flat-square)
 
@@ -18,7 +18,6 @@
 ## Summary ##
 
 - [Features](#features)
-- [Compatibilities](#compatibilities)
 - [Installation](#installation)
   - [Carthage](#carthage)
   - [CocoaPods](#cocoapods)
@@ -40,12 +39,6 @@
 - [x] Includes Swift 4 support
 - [x] Includes ready-for-consumption CRUD `URLRequest` for JSS endpoints
 - [x] Includes demonstration playgrounds for class handling or request generation
-
-## Compatibilities ##
-
-- iOS 9+ / macOS 10.10+
-- XCode 9.2+
-- Objective-C / Swift 4.1+
 
 ## Installation ##
 


### PR DESCRIPTION
# Summary #

Implement the functions that will return `URLRequests` for all requestable objects.

Implements #70 and #71.

# Miscellaneous #

Supports Objective-C meaning that each single object will implement the public version of each function but under the hood, the generic functions will be used. 😭

Supports `CREATE`, `READ`, `UPDATE` & `DELETE` methods.

